### PR TITLE
Failure to work with unixsocket

### DIFF
--- a/redis_cache/util.py
+++ b/redis_cache/util.py
@@ -70,7 +70,7 @@ class ConnectionPoolHandler(object):
 
         # port 6379
         if kwargs['unix_socket_path']:
-            kwargs['path'] = kwargs['unix_socket_path']
+            params['path'] = kwargs['unix_socket_path']
         else:
             params['host'], params['port'] = kwargs['host'], kwargs['port']
         


### PR DESCRIPTION
When trying to work with unixsocket, I got an error from python-redis indicating "Error 22 connecting to unix socket: . Invalid argument.".
I further debugged it and saw that the "path" parameter that should contain the socket is empty.

I found the blame to be in util.py:73 (in ConnectionPoolHandler.connection_pool).
Instead of:
kwargs['path'] = kwargs['unix_socket_path']
it should be:
params['path'] = kwargs['unix_socket_path']

Fixing it on my local machine fixed that error.
