### PR TITLE
delete_pattern only if there are any keys to delete

### DIFF
--- a/redis_cache/cache.py
+++ b/redis_cache/cache.py
@@ -215,7 +215,8 @@ class RedisCache(BaseCache):
 
         pattern = self.make_key(pattern, version=version)
         keys = client.keys(pattern)
-        client.delete(*keys)
+        if keys:
+            client.delete(*keys)
 
     def delete_many(self, keys, version=None):
         """


### PR DESCRIPTION
if the pattern doesn't yield any keys error is thrown:
ERR wrong number of arguments for 'del' command
