### PR TITLE
'Location' configuration error triggers a wrong exception

### DIFF
--- a/redis_cache/client.py
+++ b/redis_cache/client.py
@@ -75,7 +75,7 @@ class DefaultClient(object):
             db = int(db)
             return host, port, db
         except (ValueError, TypeError):
-            raise ImproperlyConfigured("Incorrect format '%s'" % (connection_string))
+            raise ImproperlyConfigured("Incorrect format '%s'" % (constring))
 
     def _connect(self, host, port, db):
         """


### PR DESCRIPTION
A none-existing variable called "connection_string" was referenced in the exception code when the 'Location' parameter value was wrong.
Changed it to "constring", which is the actual variable.
