### PR TITLE
DefaultClient's add method changed to use redis setnx. 

### DIFF
--- a/redis_cache/client/default.py
+++ b/redis_cache/client/default.py
@@ -175,18 +175,7 @@ class DefaultClient(object):
 
         Returns ``True`` if the object was added, ``False`` if not.
         """
-        if client is None:
-            client = self.client
-
-        key = self.make_key(key, version=version)
-
-        try:
-            if client.exists(key):
-                return False
-        except ConnectionError:
-            raise ConnectionInterrumped(connection=client)
-
-        return self.set(key, value, timeout, client=client)
+        return self.set(key, value, timeout, client=client, nx=True)
 
     def get(self, key, default=None, version=None, client=None):
         """

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -43,7 +43,7 @@ class DjangoRedisCacheTests(TestCase):
         # test that timeout still works for nx=True
         res = self.cache.set("test_key_nx", 1, timeout=2, nx=True)
         self.assertTrue(res)
-        time.sleep(2)
+        time.sleep(3)
         res = self.cache.get("test_key_nx", None)
         self.assertEqual(res, None)
 


### PR DESCRIPTION
race condition about existence of key removed. #29
