### PR TITLE
Add SOCKET_TIMEOUT option to allow redis connections to time out

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -215,6 +215,30 @@ Now, on 3.2 version, the initial behavior is reverted, and if you would memcache
 ``DJANGO_REDIS_IGNORE_EXCEPTIONS`` to True (now, by default is False)
 
 
+Specifying a timeout for Redis operations
+-----------------------------------------
+
+You can optionally set a timeout for redis operations by specifying an integer or float value for
+``SOCKET_TIMEOUT`` in your ``CACHES`` entry:
+
+.. code-block:: python
+
+    CACHES = {
+        'default': {
+            ...
+            'OPTIONS': {
+                'SOCKET_TIMEOUT': 5,
+            },
+        },
+    }
+
+If set, redis will time out after ``SOCKET_TIMEOUT`` seconds. This can occur for multiple reasons, such as
+redis being down or unavailable, or Redis not returning quickly enough if your timeout is set too low.
+
+If you have ``DJANGO_REDIS_IGNORE_EXCEPTIONS`` set to ``True``, timeouts will silently return ``None``.
+Otherwise, an exception will be raised.
+
+
 Access to raw redis connection
 ------------------------------
 

--- a/redis_cache/client/default.py
+++ b/redis_cache/client/default.py
@@ -92,6 +92,8 @@ class DefaultClient(object):
             kwargs.update({'path': port, 'connection_class': UnixDomainSocketConnection})
         else:
             kwargs.update({'host': host, 'port': port, 'connection_class': Connection})
+        if 'SOCKET_TIMEOUT' in self._options:
+            kwargs.update({'socket_timeout': int(self._options['SOCKET_TIMEOUT'])})
 
         connection_pool = get_or_create_connection_pool(**kwargs)
         connection = Redis(connection_pool=connection_pool)


### PR DESCRIPTION
Adds a simple SOCKET_TIMEOUT option to hook into the underlying Redis library. Includes docs.
