### PR TITLE
Fix DJANGO_REDIS_IGNORE_EXCEPTIONS to handle cache.get('key', 'default')

### DIFF
--- a/redis_cache/client/sharded.py
+++ b/redis_cache/client/sharded.py
@@ -2,36 +2,15 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from django.core.exceptions import ImproperlyConfigured
-
-try:
-    from django.utils.encoding import smart_bytes
-except ImportError:
-    from django.utils.encoding import smart_str as smart_bytes
-
-from django.utils.datastructures import SortedDict
-from django.utils import importlib
-from django.conf import settings
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
-from collections import defaultdict
-import functools
 import re
 
-from redis import Redis
+
+from django.utils.datastructures import SortedDict
+from django.conf import settings
 from redis.exceptions import ConnectionError
-from redis.connection import DefaultParser
-from redis.connection import UnixDomainSocketConnection, Connection
 
-from ..util import CacheKey, load_class
 from ..hash_ring import HashRing
-from ..exceptions import ConnectionInterrumped
-from ..pool import get_or_create_connection_pool
-
+from ..exceptions import ConnectionInterrupted
 from .default import DefaultClient
 
 
@@ -142,7 +121,7 @@ class ShardClient(DefaultClient):
         try:
             return client.exists(key)
         except ConnectionError:
-            raise ConnectionInterrumped(connection=client)
+            raise ConnectionInterrupted(connection=client)
 
     def delete(self, key, version=None, client=None):
         if client is None:
@@ -183,19 +162,19 @@ class ShardClient(DefaultClient):
         return super(ShardClient, self)\
             .decr(key=key, delta=delta, version=version, client=client)
 
-
     def keys(self, search):
         pattern = self.make_key(search)
-
         keys = []
-        for server, connection in self._serverdict.items():
-            keys.extend(connection.keys(pattern))
-
         try:
-            encoding_map = map(lambda x:  x.decode('utf-8'), keys)
-            return list(map(lambda x: x.split(":", 2)[2], encoding_map))
+            for server, connection in self._serverdict.items():
+                keys.extend(connection.keys(pattern))
         except ConnectionError:
-            raise ConnectionInterrumped(connection=client)
+            # FIXME: technically all clients should be passed as `connection`.
+            client = self.get_server(pattern)
+            raise ConnectionInterrupted(connection=client)
+
+        decoded_keys = map(lambda x: x.decode('utf-8'), keys)
+        return list(map(lambda x: x.split(":", 2)[2], decoded_keys))
 
     def delete_pattern(self, pattern, version=None):
         """

--- a/redis_cache/exceptions.py
+++ b/redis_cache/exceptions.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+
 class ConnectionInterrumped(Exception):
+    """Deprecated exception name with a typo."""
     def __init__(self, connection):
         self.connection = connection
+
+
+class ConnectionInterrupted(ConnectionInterrumped):
+    pass

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -32,6 +32,13 @@ CACHES = {
             'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
         }
     },
+    'doesnotexist': {
+        'BACKEND': 'redis_cache.cache.RedisCache',
+        'LOCATION': '127.0.0.1:56379:1',
+        'OPTIONS': {
+            'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
+        }
+    },
 }
 
 INSTALLED_APPS = (

--- a/tests/test_sqlite_sharding.py
+++ b/tests/test_sqlite_sharding.py
@@ -19,6 +19,10 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
+TIME_ZONE = 'America/Chicago'
+LANGUAGE_CODE = 'en-us'
+ADMIN_MEDIA_PREFIX = '/static/admin/'
+STATICFILES_DIRS = ()
 
 CACHES = {
     'default': {
@@ -31,11 +35,17 @@ CACHES = {
             'CLIENT_CLASS': 'redis_cache.client.ShardClient',
         }
     },
+    'doesnotexist': {
+        'BACKEND': 'redis_cache.cache.RedisCache',
+        'LOCATION': [
+            '127.0.0.1:56379:1',
+            '127.0.0.1:56379:2',
+        ],
+        'OPTIONS': {
+            'CLIENT_CLASS': 'redis_cache.client.ShardClient',
+        }
+    },
 }
-TIME_ZONE = 'America/Chicago'
-LANGUAGE_CODE = 'en-us'
-ADMIN_MEDIA_PREFIX = '/static/admin/'
-STATICFILES_DIRS = ()
 
 INSTALLED_APPS = (
     'redis_backend_testapp',


### PR DESCRIPTION
Includes other minor changes:
- import fixes
- renaming of `ConnectionInterrumped` to `ConnectionInterrupted`
- fixed missing `client` value while raising `ConnectionInterrupted` in the `keys()` method of the sharded client
