### PR TITLE
Connection pool class in settings

### DIFF
--- a/redis_cache/client/default.py
+++ b/redis_cache/client/default.py
@@ -47,6 +47,11 @@ class DefaultClient(object):
 
         self.setup_pickle_version()
 
+        self._pool_cls = self._options.get(
+            'CONNECTION_POOL_CLASS', 'redis.connection.ConnectionPool')
+        self._pool_cls = load_class(self._pool_cls)
+        self._pool_cls_kwargs = self._options.get('CONNECTION_POOL_KWARGS', {})
+
     def __contains__(self, key):
         return self.has_key(key)
 
@@ -100,7 +105,9 @@ class DefaultClient(object):
         if 'SOCKET_TIMEOUT' in self._options:
             kwargs.update({'socket_timeout': int(self._options['SOCKET_TIMEOUT'])})
 
-        connection_pool = get_or_create_connection_pool(**kwargs)
+        kwargs.update(self._pool_cls_kwargs)
+
+        connection_pool = get_or_create_connection_pool(self._pool_cls, **kwargs)
         connection = Redis(connection_pool=connection_pool)
         return connection
 

--- a/redis_cache/pool.py
+++ b/redis_cache/pool.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
-
-from redis import ConnectionPool
-
 _connection_pools = {}
 
 
-def get_or_create_connection_pool(**params):
+def get_or_create_connection_pool(pool_cls, **params):
     global _connection_pools
 
     key = str(params)
     if key not in _connection_pools:
-        _connection_pools[key] = ConnectionPool(**params)
+        _connection_pools[key] = pool_cls(**params)
     return _connection_pools[key]
 
 


### PR DESCRIPTION
When using multiple threads or greenlets, default `ConnectionPool` may be overlimited. `redis.connection.BlockingConnectionPool` easily solves this problem, but it can't be used without tricky monkey-patching.

Better if ConnectionPool class and its arguments would be specified in settings.
