### PR TITLE
fix import error "cannot import name timezone" for django 1.3.x

### DIFF
--- a/redis_cache/client/experimental.py
+++ b/redis_cache/client/experimental.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
-from django.utils import timezone
+try:
+    from django.utils.timezone import now as datetime_now
+    assert datetime_now
+except ImportError:
+    import datetime
+    datetime_now = datetime.datetime.now
 from .default import DefaultClient
 from ..exceptions import ConnectionInterrumped
 import functools
@@ -16,7 +21,7 @@ def auto_failover(method):
     @functools.wraps(method)
     def _decorator(self, *args, **kwargs):
         if self._in_fallback:
-            pass_seconds = (timezone.now() - self._in_fallback_date).total_seconds()
+            pass_seconds = (datetime_now() - self._in_fallback_date).total_seconds()
             if pass_seconds > self._options.get("FAILOVER_TIME", 30):
                 print("Go to default connection")
                 self._client = self._old_client


### PR DESCRIPTION
django.utils.timezone was not added in django 1.3.
