### PR TITLE
Share Redis connection pool across Django requests 

### DIFF
--- a/redis_cache/pool.py
+++ b/redis_cache/pool.py
@@ -11,14 +11,19 @@ from . import util
 
 
 class ConnectionFactory(object):
+
+    #: Store connection pool by cache backend options.
+    #: _pools is a process-global, as
+    #: otherwise _pools is cleared every time ConnectionFactory is instiated,
+    #: as Django creates new cache client (DefaultClient) instance for every request.
+    _pools = {}
+
     def __init__(self, options):
         pool_cls_path = options.get("CONNECTION_POOL_CLASS",
                                     "redis.connection.ConnectionPool")
         self.pool_cls = util.load_class(pool_cls_path)
         self.pool_cls_kwargs = options.get("CONNECTION_POOL_KWARGS", {})
         self.options = options
-
-        self._pools = {}
 
     def make_connection_params(self, host, port, db):
         """


### PR DESCRIPTION
Django 1.6 and lower compatible way to share Redis connection across HTTP requests.
