### PR TITLE
Fix a bunch of typos and tweak some wording.

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ In active development
 </li>
 <li>
 <p>
-Modular client system (pluggable clients)
+Modular client system (plugable clients)
 </p>
 </li>
 <li>
@@ -119,7 +119,7 @@ Plugable parsers.
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_configure_as_cache_backend">4.1. Configure as cache backend</h3>
-<div class="paragraph"><p>For start using <strong>django-redis</strong>, you should change your django cache settings to something
+<div class="paragraph"><p>To start using <strong>django-redis</strong>, you should change your django cache settings to something
 like this:</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="n">CACHES</span> <span class="o">=</span> <span class="p">{</span>
@@ -134,8 +134,8 @@ like this:</p></div>
 <span class="p">}</span>
 </pre></div></div></div>
 <div class="paragraph"><p>On this example, we are using standard TCP/IP sockets connection to localhost redis and using database 1.
-In <span class="monospaced">OPTIONS</span>, we have especified the plugable client that we want use; in this case the default. You can ommit
-this part because that client is used by default if no one is specified.</p></div>
+In <span class="monospaced">OPTIONS</span>, we have specified the plugable client that we want to use; in this case the default. You can omit
+this part because that client is used by default if one is not specified.</p></div>
 <div class="admonitionblock">
 <table><tr>
 <td class="icon">
@@ -147,8 +147,8 @@ this part because that client is used by default if no one is specified.</p></di
 </div>
 <div class="sect2">
 <h3 id="_configure_as_session_backend">4.2. Configure as session backend</h3>
-<div class="paragraph"><p>Django, by default can use any cache backend as session backend and you can take profit of it using <strong>django-redis</strong>
-as backend for session storage whithout installing any additional and unnecesary backends:</p></div>
+<div class="paragraph"><p>Django, by default can use any cache backend as session backend and you can profit from it using <strong>django-redis</strong>
+as backend for session storage without installing any additional and unnecessary backends:</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="n">SESSION_ENGINE</span> <span class="o">=</span> <span class="s">&quot;django.contrib.sessions.backends.cache&quot;</span>
 <span class="n">SESSION_CACHE_ALIAS</span> <span class="o">=</span> <span class="s">&quot;default&quot;</span>
@@ -161,18 +161,18 @@ as backend for session storage whithout installing any additional and unnecesary
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_pickle_version">5.1. Pickle version</h3>
-<div class="paragraph"><p><strong>django-redis</strong> for al most all values uses pickle for serialize objects and it, by default uses the
-last pickle protocol version, but if you want set a custom version you can do it with <strong>PICKLE_VERSION</strong> key
+<div class="paragraph"><p><strong>django-redis</strong> uses pickle for almost all values to serialize objects and by default it uses the
+latest pickle protocol version, but if you want set a custom version you can do it with the <strong>PICKLE_VERSION</strong> key
 on <strong>OPTIONS</strong>:</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="s">&quot;OPTIONS&quot;</span><span class="p">:</span> <span class="p">{</span>
-    <span class="s">&quot;PICKLE_VERSION&quot;</span><span class="p">:</span> <span class="o">-</span><span class="mi">1</span> <span class="c"># Use the last</span>
+    <span class="s">&quot;PICKLE_VERSION&quot;</span><span class="p">:</span> <span class="o">-</span><span class="mi">1</span> <span class="c"># Use the latest</span>
 <span class="p">}</span>
 </pre></div></div></div>
 </div>
 <div class="sect2">
 <h3 id="_socket_timeout">5.2. Socket timeout</h3>
-<div class="paragraph"><p>You can set socket timeout using <strong>SOCKET_TIMEOUT</strong> key on <strong>OPTIONS</strong> dict:</p></div>
+<div class="paragraph"><p>You can set socket timeout using the <strong>SOCKET_TIMEOUT</strong> key on the <strong>OPTIONS</strong> dict:</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="s">&quot;OPTIONS&quot;</span><span class="p">:</span> <span class="p">{</span>
     <span class="s">&quot;SOCKET_TIMEOUT&quot;</span><span class="p">:</span> <span class="mi">5</span><span class="p">,</span> <span class="c"># in segons</span>
@@ -181,7 +181,7 @@ on <strong>OPTIONS</strong>:</p></div>
 </div>
 <div class="sect2">
 <h3 id="_memcached_exceptions_behavior">5.3. Memcached exceptions behavior</h3>
-<div class="paragraph"><p>In some situations, when redis is only used for cache you do not want exceptios when redis is down. This is
+<div class="paragraph"><p>In some situations, when redis is only used for cache, you do not want exceptions when redis is down. This is
 a default behavior with memcached backend and it can be emulated with <strong>django-redis</strong>.</p></div>
 <div class="paragraph"><p>You can ignore exceptions globally (for all configured redis cache clients) setting <strong>DJANGO_REDIS_IGNORE_EXCEPTIONS</strong>
 to <span class="monospaced">True</span> in your settings.</p></div>
@@ -194,11 +194,11 @@ to <span class="monospaced">True</span> in your settings.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_infinite_timeout">5.4. Infinite timeout</h3>
-<div class="paragraph"><p><strong>django-redis</strong> comes with infinite timeouts support from before django has added it (with django 1.6 version).</p></div>
+<div class="paragraph"><p><strong>django-redis</strong> comes with infinite timeouts support from before django added it (with django 1.6 version).</p></div>
 <div class="paragraph"><p>Before django 1.6, django-redis interprets 0 timeout value as infinite value and with django&gt;=1.6 it also supports
 <span class="monospaced">None</span> as timeout value.</p></div>
 <div class="listingblock">
-<div class="title">This statements now are equivalent</div>
+<div class="title">These statements are now equivalent</div>
 <div class="content"><div class="highlight"><pre><span class="n">cache</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="s">&#39;key&#39;</span><span class="p">,</span> <span class="s">&#39;value&#39;</span><span class="p">,</span> <span class="n">timeout</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span>
 <span class="n">cache</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="s">&#39;key&#39;</span><span class="p">,</span> <span class="s">&#39;value&#39;</span><span class="p">,</span> <span class="n">timeout</span><span class="o">=</span><span class="bp">None</span><span class="p">)</span>
 </pre></div></div></div>
@@ -248,8 +248,8 @@ to <span class="monospaced">True</span> in your settings.</p></div>
 <div class="sect2">
 <h3 id="_raw_client_access">5.7. Raw client access</h3>
 <div class="paragraph"><p>In some situations, your application should require access to raw redis client for use some other advanced
-features that aren&#8217;t exposed by django cache interface. For avoid store an other settings for creating a raw
-connection, <strong>django-redis</strong> exposes functions with that you can obtain a raw client reusing cache connection
+features that aren&#8217;t exposed by the django cache interface. To avoid storing another setting for creating a raw
+connection, <strong>django-redis</strong> exposes functions with which you can obtain a raw client reusing cache connection
 string: <span class="monospaced">get_redis_connection(alias)</span>.</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="o">&gt;&gt;&gt;</span> <span class="kn">from</span> <span class="nn">redis_cache</span> <span class="kn">import</span> <span class="n">get_redis_connection</span>
@@ -270,12 +270,12 @@ string: <span class="monospaced">get_redis_connection(alias)</span>.</p></div>
 <h3 id="_connection_pools">5.8. Connection pools</h3>
 <div class="paragraph"><p>django-redis, behind the scenes uses underlying redis-py connection pool implementation, and exposes a simple way to
 configure it or directly customize a connection/connection pool creation for backend.</p></div>
-<div class="paragraph"><p>The default redis-py behavior is not to close connections and recycle them when possible.</p></div>
+<div class="paragraph"><p>The default redis-py behavior is to not close connections and recycle them when possible.</p></div>
 <div class="sect3">
 <h4 id="_configure_default_connection_pool">5.8.1. Configure default connection pool</h4>
 <div class="paragraph"><p>The default connection pool is simple. You only can customize the maximum number of connections
 for the pool.</p></div>
-<div class="paragraph"><p>You can do it, using <strong>CONNECTION_POOL_KWARGS</strong> parameter in settings CACHES:</p></div>
+<div class="paragraph"><p>You can do it, using the <strong>CONNECTION_POOL_KWARGS</strong> parameter in settings CACHES:</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="n">CACHES</span> <span class="o">=</span> <span class="p">{</span>
     <span class="s">&quot;default&quot;</span><span class="p">:</span> <span class="p">{</span>
@@ -298,8 +298,8 @@ for the pool.</p></div>
 </div>
 <div class="sect3">
 <h4 id="_use_your_own_connection_pool_subclass">5.8.2. Use your own connection pool subclass</h4>
-<div class="paragraph"><p>Also, in some momments you want put your own subclass of connection pool. It is also possible with
-django-redis using <strong>CONNECTION_POOL_CLASS</strong> parameter on the backend options.</p></div>
+<div class="paragraph"><p>Also, in some moments you want to use your own subclass of connection pool. This is also possible with
+django-redis using the <strong>CONNECTION_POOL_CLASS</strong> parameter on the backend options.</p></div>
 <div class="listingblock">
 <div class="title"><em>myproj/mypool.py</em></div>
 <div class="content"><div class="highlight"><pre><span class="kn">from</span> <span class="nn">redis.connection</span> <span class="kn">import</span> <span class="n">ConnectionPool</span>
@@ -319,48 +319,48 @@ django-redis using <strong>CONNECTION_POOL_CLASS</strong> parameter on the backe
 </div>
 <div class="sect3">
 <h4 id="_customize_connection_factory">5.8.3. Customize connection factory</h4>
-<div class="paragraph"><p>If no one of the previously methods satisfies you, you can get in the middle of django-redis connection
-factory process and customize it or completely rewrite.</p></div>
-<div class="paragraph"><p>django-redis by default creates connection throught <span class="monospaced">redis_cache.pool.ConnectionFactory</span> class that is specifid
-throught <strong>DJANGO_REDIS_CONNECTION_FACTORY</strong> global django setting.</p></div>
+<div class="paragraph"><p>If no one of the previous methods satisfies you, you can get in the middle of django-redis connection
+factory process and customize or completely rewrite it.</p></div>
+<div class="paragraph"><p>django-redis by default creates connections through the <span class="monospaced">redis_cache.pool.ConnectionFactory</span> class that is specified
+through the global <strong>DJANGO_REDIS_CONNECTION_FACTORY</strong> django setting.</p></div>
 <div class="listingblock">
 <div class="title">Partial interface of <span class="monospaced">ConnectionFactory</span> class</div>
 <div class="content"><div class="highlight"><pre><span class="c"># Note: using python3 notations for code documentation ;)</span>
 
 <span class="k">class</span> <span class="nc">ConnectionFactory</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
     <span class="k">def</span> <span class="nf">get_connection_pool</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">params</span><span class="p">:</span><span class="nb">dict</span><span class="p">):</span>
-        <span class="c"># Given a connection parameters on `params` argument</span>
+        <span class="c"># Given connection parameters in `params` argument</span>
         <span class="c"># return new connection pool.</span>
-        <span class="c"># It should be overwrited if you want do something</span>
+        <span class="c"># It should be overwritten if you want do something</span>
         <span class="c"># before/after create connection pool or return your</span>
         <span class="c"># own connection pool.</span>
         <span class="k">pass</span>
 
     <span class="k">def</span> <span class="nf">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">params</span><span class="p">:</span><span class="nb">dict</span><span class="p">):</span>
-        <span class="c"># Given a connection parameters on `params` argument</span>
+        <span class="c"># Given connection parameters in `params` argument</span>
         <span class="c"># return a new connection.</span>
-        <span class="c"># It should be overwrited if you want do something</span>
+        <span class="c"># It should be overwritten if you want do something</span>
         <span class="c"># before/after create new connection.</span>
         <span class="c"># The default implementation uses `get_connection_pool`</span>
-        <span class="c"># for obtain a pool and create new connection from</span>
+        <span class="c"># to obtain a pool and create new connection from</span>
         <span class="c"># newly obtained pool.</span>
         <span class="k">pass</span>
 
     <span class="k">def</span> <span class="nf">get_or_create_connection_pool</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">params</span><span class="p">:</span><span class="nb">dict</span><span class="p">):</span>
         <span class="c"># This is a high layer on top of get_connection_pool for</span>
-        <span class="c"># implement a cache of created connection pools.</span>
+        <span class="c"># implementing a cache of created connection pools.</span>
         <span class="c"># You should reimplement it if you want change the default</span>
         <span class="c"># behavior.</span>
         <span class="k">pass</span>
 
     <span class="k">def</span> <span class="nf">make_connection_params</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">host</span><span class="p">:</span><span class="nb">str</span><span class="p">,</span> <span class="n">port</span><span class="p">:</span><span class="nb">int</span><span class="p">,</span> <span class="n">db</span><span class="p">:</span><span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">dict</span><span class="p">:</span>
-        <span class="c"># The resposability of this function is conver basic connection</span>
+        <span class="c"># The responsibility of this function is to convert basic connection</span>
         <span class="c"># parameters and other settings to fully connection pool ready</span>
         <span class="c"># connection parameters</span>
         <span class="k">pass</span>
 
     <span class="k">def</span> <span class="nf">connect</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">host</span><span class="p">:</span><span class="nb">str</span><span class="p">,</span> <span class="n">port</span><span class="p">:</span><span class="nb">int</span><span class="p">,</span> <span class="n">db</span><span class="p">:</span><span class="nb">int</span><span class="p">):</span>
-        <span class="c"># This is a really public api and entry point of this</span>
+        <span class="c"># This is really a public api and entry point of this</span>
         <span class="c"># factory class. This encapsulates the main logic of creating</span>
         <span class="c"># the previously mentioned `params` using a `make_connection_params`</span>
         <span class="c"># and creating a new connection using `get_connection` method.</span>
@@ -371,8 +371,8 @@ throught <strong>DJANGO_REDIS_CONNECTION_FACTORY</strong> global django setting.
 <div class="sect2">
 <h3 id="_plugable_parsers">5.9. Plugable parsers</h3>
 <div class="paragraph"><p>redis-py (python redis client used by django-redis) comes with pure python redis parser that works very
-well for al most common task, but if you want some performance boost, you can use <strong>hiredis</strong>.</p></div>
-<div class="paragraph"><p><strong>hiredis</strong> is a redis client writen in C and it has it own parser that can be used with <strong>django-redis</strong>.</p></div>
+well for almost any common task, but if you want some performance boost, you can use <strong>hiredis</strong>.</p></div>
+<div class="paragraph"><p><strong>hiredis</strong> is a redis client written in C and it has it own parser that can be used with <strong>django-redis</strong>.</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="s">&quot;OPTIONS&quot;</span><span class="p">:</span> <span class="p">{</span>
     <span class="s">&quot;PARSER_CLASS&quot;</span><span class="p">:</span> <span class="s">&quot;redis.connection.HiredisParser&quot;</span><span class="p">,</span>
@@ -380,7 +380,7 @@ well for al most common task, but if you want some performance boost, you can us
 </pre></div></div></div>
 </div>
 <div class="sect2">
-<h3 id="_pluggable_clients">5.10. Pluggable clients</h3>
+<h3 id="_plugable_clients">5.10. Plugable clients</h3>
 <div class="sect3">
 <h4 id="_default_client">5.10.1. Default client</h4>
 <div class="paragraph"><p>Additionally to previously explained, default client comes with master-slave connection support. For
@@ -403,7 +403,7 @@ use master-slave configuration on your project, you should change you <strong>LO
 <div class="sect3">
 <h4 id="_shard_client">5.10.2. Shard client</h4>
 <div class="paragraph"><p>This plugable client implements client-side sharding. It inherits almost all functionality from
-the default client. For use it, you change your cache settings to something like this:</p></div>
+the default client. To use it, you change your cache settings to something like this:</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="n">CACHES</span> <span class="o">=</span> <span class="p">{</span>
     <span class="s">&quot;default&quot;</span><span class="p">:</span> <span class="p">{</span>
@@ -445,7 +445,7 @@ login for get/set keys.</p></div>
     <span class="p">}</span>
 <span class="p">}</span>
 </pre></div></div></div>
-<div class="paragraph"><p>This client, exposes additional settings:</p></div>
+<div class="paragraph"><p>This client exposes additional settings:</p></div>
 <div class="ulist"><ul>
 <li>
 <p>
@@ -457,7 +457,7 @@ login for get/set keys.</p></div>
 <div class="sect3">
 <h4 id="_auto_failover_client">5.10.4. Auto Failover client</h4>
 <div class="paragraph"><p>This plugable experimental client offers simple failover algorithm if the main redis server turns down.</p></div>
-<div class="paragraph"><p>For setup, you should change your cache settings to somethin like this:</p></div>
+<div class="paragraph"><p>For setup, you should change your cache settings to something like this:</p></div>
 <div class="listingblock">
 <div class="content"><div class="highlight"><pre><span class="n">CACHES</span> <span class="o">=</span> <span class="p">{</span>
     <span class="s">&quot;default&quot;</span><span class="p">:</span> <span class="p">{</span>
@@ -469,8 +469,8 @@ login for get/set keys.</p></div>
     <span class="p">}</span>
 <span class="p">}</span>
 </pre></div></div></div>
-<div class="paragraph"><p>The big difference is that each key on <strong>LOCATION</strong> setting list can contain two connection strings
-separated by "/". A second connection strings works as failover server.</p></div>
+<div class="paragraph"><p>The big difference is that each key in the <strong>LOCATION</strong> setting list can contain two connection strings
+separated by "/". A second connection string works as failover server.</p></div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
This fixes some typos throughout the documentation, as well as shuffles around a few wordings to make the text flow better when reading it. Have a look at the change set for details on what have been modified.
