### PR TITLE
Option COMPRESS_MIN_LEN to compress values using zlib

### DIFF
--- a/redis_cache/client/default.py
+++ b/redis_cache/client/default.py
@@ -8,6 +8,7 @@ except ImportError:
     import pickle
 
 import random
+import zlib
 
 try:
     from django.utils.encoding import smart_bytes
@@ -44,6 +45,9 @@ class DefaultClient(object):
 
         self._clients = [None] * len(self._server)
         self._options = params.get('OPTIONS', {})
+        self._options.setdefault('COMPRESS_COMPRESSOR', zlib.compress)
+        self._options.setdefault('COMPRESS_DECOMPRESSOR', zlib.decompress)
+        self._options.setdefault('COMPRESS_DECOMPRESSOR_ERROR', zlib.error)
 
         self.setup_pickle_version()
 
@@ -267,14 +271,19 @@ class DefaultClient(object):
 
         client.flushdb()
 
-    @staticmethod
-    def unpickle(value):
+    def unpickle(self, value):
         """
         Unpickles the given value.
         """
         try:
             value = int(value)
         except (ValueError, TypeError):
+            if self._options.get('COMPRESS_MIN_LEN', 0) > 0:
+                try:
+                    value = self._options['COMPRESS_DECOMPRESSOR'](value)
+                except self._options['COMPRESS_DECOMPRESSOR_ERROR']:
+                    # Handle little values, chosen to be not compressed
+                    pass
             value = smart_bytes(value)
             value = pickle.loads(value)
         return value
@@ -285,7 +294,15 @@ class DefaultClient(object):
         """
 
         if isinstance(value, bool) or not isinstance(value, integer_types):
-            return pickle.dumps(value, self._pickle_version)
+            pickled_value = pickle.dumps(value, self._pickle_version)
+            if self._options.get('COMPRESS_MIN_LEN', 0) > 0:
+                if len(pickled_value) >= self._options['COMPRESS_MIN_LEN']:
+                    # We should try to compress if COMPRESS_MIN_LEN > 0
+                    # and this string is longer than our min threshold.
+                    compressed = self._options['COMPRESS_COMPRESSOR'](pickled_value)
+                    if len(compressed) < len(pickled_value):
+                        pickled_value = compressed
+            return pickled_value
 
         return value
 


### PR DESCRIPTION
Inspired by python-memcache, this adds the OPTIONs:
- COMPRESS_MIN_LEN: Minimum size to compress the values
- COMPRESS_COMPRESSOR: callable that compress the values,
- COMPRESS_DECOMPRESSOR: callable that decompress the values,
- COMPRESS_DECOMPRESSOR_ERROR: exception to be ignored when decompressing the values. 

YMMV, but here this made possible a 60-70% reduction on real-world access time when django caches the ORM via https://github.com/jmoiron/johnny-cache/

Before: https://rpm.newrelic.com/public/charts/j0qRCwRvtNq
After: https://rpm.newrelic.com/public/charts/hclMlVeb5Hb

Caveats:
- No tests and no docs for now.
- If you switch from compressed to non-compressed, you should clear you cache.
