### PR TITLE
Remove testing and suport for end-of-life Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,6 @@ matrix:
   include:
     - env: TOXENV=lint
     - python: 3.5
-      env: TOXENV=py35-django111-redis2
-    - python: 3.5
-      env: TOXENV=py35-django111-redislatest
-    - python: 3.5
-      env: TOXENV=py35-django111-redismaster
-    - python: 3.6
-      env: TOXENV=py36-django111-redis2
-    - python: 3.6
-      env: TOXENV=py36-django111-redislatest
-    - python: 3.6
-      env: TOXENV=py36-django111-redismaster
-    - python: 3.5
       env: TOXENV=py35-django22-redis2
     - python: 3.5
       env: TOXENV=py35-django22-redislatest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+- Removed support for end-of-life Django < 2.2.
+
 Version 4.11.0
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Requirements
 Django version support
 ^^^^^^^^^^^^^^^^^^^^^^
 
-- django-redis supports Django 1.11+.
+- django-redis supports Django 2.+.
 
 
 Redis Server Support

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.11
+Django>=2.2
 flake8
 isort
 msgpack>=0.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers = [
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Intended Audience :: Developers
@@ -35,7 +34,7 @@ packages =
     django_redis.serializers
     django_redis.compressors
 install_requires =
-    Django>=1.11
+    Django>=2.2
     redis>=2.10.0
 
 [flake8]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -7,7 +7,6 @@ import unittest
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
-from django import VERSION
 from django.conf import settings
 from django.contrib.sessions.backends.cache import SessionStore as CacheSession
 from django.core.cache import DEFAULT_CACHE_ALIAS, cache, caches
@@ -1081,7 +1080,6 @@ class SessionTestsMixin:
                 self.session.delete(old_session_key)
                 self.session.delete(new_session_key)
 
-    @unittest.skipIf(VERSION < (2, 0), "Requires Django 2.0+")
     def test_session_load_does_not_create_record(self):
         """
         Loading an unknown session key does not create a session record.

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     lint
-    py{35,36}-django111-redis{2,latest,master}
     py{35,36,37,38}-django22-redis{2,latest,master}
     py{36,37,38}-django30-redis{2,latest,master}
     py{36,37,38}-djangomaster-redis{2,latest,master}
@@ -18,7 +17,6 @@ commands =
   {envpython} -b -Wa tests/runtests-lz4.py -v2
 
 deps =
-    django111: Django>=1.11,<2.0
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Django 1.11 went EOL April 1, 2020:
https://www.djangoproject.com/download/#supported-versions