### PR TITLE
add redis sentinel support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,17 @@ jobs:
           - 'latest'
           - 'master'
 
+    services:
+      redis:
+        image: redis:latest
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+        - 6379:6379
+
     steps:
     - uses: actions/checkout@v2
 
@@ -31,9 +42,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Start Redis
-      uses: supercharge/redis-github-action@1.1.0
 
     - name: Get pip cache dir
       id: pip-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,34 @@ jobs:
 
     - name: Tox tests
       run: |
+        # setup a redis sentinel
+        CONF=$(mktemp)
+
+        cat > "$CONF" <<EOF
+        sentinel monitor default_service 127.0.0.1 6379 1
+        sentinel down-after-milliseconds default_service 3200
+        sentinel failover-timeout default_service 10000
+        sentinel parallel-syncs default_service 1
+        EOF
+
+        # start and wait for the sentinel to be healthy
+        REDIS_SENTINEL=$(docker run \
+          --health-cmd 'redis-cli -p 26379:26379 ping' \
+          --health-interval 10s \
+          --health-retries 5 \
+          --health-timeout 5s \
+          --network host \
+          --user $(id -u):$(id -g) \
+          --volume /tmp:/tmp \
+          --detach redis:latest redis-server "$CONF" --sentinel)
+        trap "docker stop $REDIS_SENTINEL" EXIT
+        while
+          docker inspect $REDIS_SENTINEL \
+            --format '{{.State.Health.Status}}' \
+              | grep -q starting
+        do sleep 1
+        done
+
         tox -v
       env:
         DJANGO: ${{ matrix.django-version }}

--- a/django_redis/client/__init__.py
+++ b/django_redis/client/__init__.py
@@ -1,5 +1,6 @@
 from .default import DefaultClient
 from .herd import HerdClient
+from .sentinel import SentinelClient
 from .sharded import ShardClient
 
-__all__ = ["DefaultClient", "ShardClient", "HerdClient"]
+__all__ = ["DefaultClient", "HerdClient", "SentinelClient", "ShardClient"]

--- a/django_redis/client/sentinel.py
+++ b/django_redis/client/sentinel.py
@@ -1,0 +1,41 @@
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from django.core.exceptions import ImproperlyConfigured
+from redis.sentinel import SentinelConnectionPool
+
+from .default import DefaultClient
+
+
+def replace_query(url, query):
+    return urlunparse((*url[:4], urlencode(query, doseq=True), url[5]))
+
+
+class SentinelClient(DefaultClient):
+    """
+    Sentinel client which uses the single redis URL specified by the CACHE's
+    LOCATION to create a LOCATION configuration for two connection pools; One
+    pool for the primaries and another pool for the replicas, and upon
+    connecting ensures the connection pool factory is configured correctly.
+    """
+
+    def __init__(self, server, params, backend):
+        if isinstance(server, str):
+            url = urlparse(server)
+            primary_query = parse_qs(url.query, keep_blank_values=True)
+            replica_query = dict(primary_query)
+            primary_query["is_master"] = [1]
+            replica_query["is_master"] = [0]
+
+            server = [replace_query(url, i) for i in (primary_query, replica_query)]
+
+        super().__init__(server, params, backend)
+
+    def connect(self, *args, **kwargs):
+        connection = super().connect(*args, **kwargs)
+        if not isinstance(connection.connection_pool, SentinelConnectionPool):
+            raise ImproperlyConfigured(
+                "Settings DJANGO_REDIS_CONNECTION_FACTORY or "
+                "CACHE[].OPTIONS.CONNECTION_POOL_CLASS is not configured correctly."
+            )
+
+        return connection

--- a/django_redis/pool.py
+++ b/django_redis/pool.py
@@ -1,6 +1,10 @@
+from urllib.parse import parse_qs, urlparse
+
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-from redis.connection import DefaultParser
+from redis.connection import DefaultParser, to_bool
+from redis.sentinel import Sentinel
 
 
 class ConnectionFactory:
@@ -113,6 +117,53 @@ class ConnectionFactory:
         if pool.connection_kwargs.get("password", None) is None:
             pool.connection_kwargs["password"] = params.get("password", None)
             pool.reset()
+
+        return pool
+
+
+class SentinelConnectionFactory(ConnectionFactory):
+    def __init__(self, options):
+        # allow overriding the default SentinelConnectionPool class
+        options.setdefault(
+            "CONNECTION_POOL_CLASS", "redis.sentinel.SentinelConnectionPool"
+        )
+        super().__init__(options)
+
+        sentinels = options.get("SENTINELS")
+        if not sentinels:
+            raise ImproperlyConfigured(
+                "SENTINELS must be provided as a list of (host, port)."
+            )
+
+        # provide the connection pool kwargs to the sentinel in case it
+        # needs to use the socket options for the sentinels themselves
+        connection_kwargs = self.make_connection_params(None)
+        connection_kwargs.pop("url")
+        connection_kwargs.update(self.pool_cls_kwargs)
+        self._sentinel = Sentinel(
+            sentinels,
+            sentinel_kwargs=options.get("SENTINEL_KWARGS"),
+            **connection_kwargs,
+        )
+
+    def get_connection_pool(self, params):
+        """
+        Given a connection parameters, return a new sentinel connection pool
+        for them.
+        """
+        url = urlparse(params["url"])
+
+        # explicitly set service_name and sentinel_manager for the
+        # SentinelConnectionPool constructor since will be called by from_url
+        cp_params = dict(params)
+        cp_params.update(service_name=url.hostname, sentinel_manager=self._sentinel)
+        pool = super().get_connection_pool(cp_params)
+
+        # convert "is_master" to a boolean if set on the URL, otherwise if not
+        # provided it defaults to True.
+        is_master = parse_qs(url.query).get("is_master")
+        if is_master:
+            pool.is_master = to_bool(is_master[0])
 
         return pool
 

--- a/tests/README.txt
+++ b/tests/README.txt
@@ -12,6 +12,13 @@ redis
 ~~~~~
 
 * redis listening on default socket 127.0.0.1:6379
+* for runtests-sentinel.py: redis sentinel listening on default socket
+  127.0.0.1:26379 with the following config:
+
+    sentinel monitor default_service 127.0.0.1 6379 1
+    sentinel down-after-milliseconds default_service 3200
+    sentinel failover-timeout default_service 10000
+    sentinel parallel-syncs default_service 1
 
 After this, run this command:
 

--- a/tests/runtests-sentinel.py
+++ b/tests/runtests-sentinel.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_sentinel")
+
+if __name__ == "__main__":
+    from django.core.management import execute_from_command_line
+
+    args = sys.argv
+    args.insert(1, "test")
+    execute_from_command_line(args)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -38,7 +38,9 @@ class DjangoRedisConnectionStrings(unittest.TestCase):
             "redis://localhost/2",
             "rediss://localhost:3333?db=2",
         ]
-        cf = pool.get_connection_factory(options={})
+        cf = pool.get_connection_factory(
+            path="django_redis.pool.ConnectionFactory", options={}
+        )
         for connection_string in connection_strings:
             with self.subTest(connection_string):
                 res = cf.make_connection_params(connection_string)

--- a/tests/test_sqlite_sentinel.py
+++ b/tests/test_sqlite_sentinel.py
@@ -1,0 +1,45 @@
+SECRET_KEY = "django_tests_secret_key"
+
+DJANGO_REDIS_CONNECTION_FACTORY = "django_redis.pool.SentinelConnectionFactory"
+
+SENTINELS = [("127.0.0.1", 26379)]
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": ["redis://default_service?db=5"],
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SENTINELS": SENTINELS,
+        },
+    },
+    "doesnotexist": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://missing_service?db=1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SENTINELS": SENTINELS,
+        },
+    },
+    "sample": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://default_service?db=1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.SentinelClient",
+            "SENTINELS": SENTINELS,
+        },
+    },
+    "with_prefix": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://default_service?db=1",
+        "KEY_PREFIX": "test-prefix",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SENTINELS": SENTINELS,
+        },
+    },
+}
+
+# TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
+
+INSTALLED_APPS = ["django.contrib.sessions"]

--- a/tox.ini
+++ b/tox.ini
@@ -22,13 +22,14 @@ REDIS =
 
 [testenv]
 commands =
-  {envpython} -b -Wa tests/runtests.py
-  {envpython} -b -Wa tests/runtests-sharded.py
-  {envpython} -b -Wa tests/runtests-herd.py
-  {envpython} -b -Wa tests/runtests-json.py
-  {envpython} -b -Wa tests/runtests-msgpack.py
-  {envpython} -b -Wa tests/runtests-zlib.py
-  {envpython} -b -Wa tests/runtests-lz4.py
+  {envpython} -b -Wa tests/runtests.py {posargs}
+  {envpython} -b -Wa tests/runtests-sentinel.py {posargs}
+  {envpython} -b -Wa tests/runtests-sharded.py {posargs}
+  {envpython} -b -Wa tests/runtests-herd.py {posargs}
+  {envpython} -b -Wa tests/runtests-json.py {posargs}
+  {envpython} -b -Wa tests/runtests-msgpack.py {posargs}
+  {envpython} -b -Wa tests/runtests-zlib.py {posargs}
+  {envpython} -b -Wa tests/runtests-lz4.py {posargs}
 
 deps =
     dj22: Django>=2.2,<2.3


### PR DESCRIPTION
This change adds an additional connection pool factory which can create Redis SentinelConnectionPool instances. Although prior work mainly contained the code in a specialized client, looking at redis-py and how it was written, this actually seemed like a more consistent implementation with regards to how this package implements its shared connection pool and the upstream sentinel support.

This code was inspired by the following:

- django-redis-sentinel [1] [2]
- django-redis-sentinel-redux [3]

[1]: https://github.com/KabbageInc/django-redis-sentinel
[2]: https://github.com/SpatialBuzz/django-redis-sentinel
[3]: https://github.com/danigosa/django-redis-sentinel-redux

fixes: #426