### PR TITLE
 Simplify isort config using 'profile = black'

### DIFF
--- a/django_redis/compressors/lz4.py
+++ b/django_redis/compressors/lz4.py
@@ -1,4 +1,5 @@
-from lz4.frame import compress as _compress, decompress as _decompress
+from lz4.frame import compress as _compress
+from lz4.frame import decompress as _decompress
 
 from ..exceptions import CompressorError
 from .base import BaseCompressor

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,11 +45,4 @@ ignore =
 max-line-length = 88
 
 [isort]
-combine_as_imports = true
-default_section = THIRDPARTY
-force_grid_wrap = 0
-include_trailing_comma = true
-known_first_party = django_redis
-line_length = 88
-multi_line_output = 3
-use_parentheses = true
+profile = black

--- a/tox.ini
+++ b/tox.ini
@@ -34,5 +34,5 @@ commands =
 deps =
     black
     flake8
-    isort >= 5.0.0
+    isort >= 5.0.2
 skip_install = true


### PR DESCRIPTION
isort now has builtin support for black through its "profiles" feature.

https://timothycrosley.github.io/isort/docs/configuration/profiles/#black