### PR TITLE
Fix for lint issue

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -323,13 +323,18 @@ class DjangoRedisCacheTests(unittest.TestCase):
 
         with patch.object(pipeline, "set") as mocked_set:
             self.cache.set(
-                key, value, client=pipeline,
+                key,
+                value,
+                client=pipeline,
             )
 
         if isinstance(self.cache.client, herd.HerdClient):
             default_timeout = self.cache.client._backend.default_timeout
             herd_timeout = (default_timeout + herd.CACHE_HERD_TIMEOUT) * 1000
-            herd_pack_value = self.cache.client._pack(value, default_timeout,)
+            herd_pack_value = self.cache.client._pack(
+                value,
+                default_timeout,
+            )
             mocked_set.assert_called_once_with(
                 self.cache.client.make_key(key, version=None),
                 self.cache.client.encode(herd_pack_value),


### PR DESCRIPTION
Hi,
Job (TOXENV=lint) was failing for Intel architecture on travis-ci. I had added the fix for the issue in PR.
Kindly review and merge if found relevant