### PR TITLE
Drop support for EOL Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ cache: pip
 matrix:
   include:
     - env: TOXENV=lint
-    - python: 3.5
-      env: TOXENV=py35-django22-redislatest
-    - python: 3.5
-      env: TOXENV=py35-django22-redismaster
     - python: 3.6
       env: TOXENV=py36-django22-redislatest
     - python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Why use django-redis?
 Requirements
 ~~~~~~~~~~~~
 
-- `Python`_ 3.5+
+- `Python`_ 3.6+
 - `Django`_ 2.2+
 - `redis-py`_ 3.0+
 - `Redis server`_ 2.8+

--- a/django_redis/exceptions.py
+++ b/django_redis/exceptions.py
@@ -5,7 +5,7 @@ class ConnectionInterrupted(Exception):
     def __str__(self):
         error_type = type(self.__cause__).__name__
         error_msg = str(self.__cause__)
-        return "Redis {}: {}".format(error_type, error_msg)
+        return f"Redis {error_type}: {error_msg}"
 
 
 class CompressorError(Exception):

--- a/django_redis/hash_ring.py
+++ b/django_redis/hash_ring.py
@@ -17,7 +17,7 @@ class HashRing:
         self.nodes.append(node)
 
         for x in range(self.replicas):
-            _key = "{}:{}".format(node, x)
+            _key = f"{node}:{x}"
             _hash = hashlib.sha256(_key.encode()).hexdigest()
 
             self.ring[_hash] = node

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -28,7 +27,7 @@ classifiers =
     Topic :: Utilities
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 packages =
     django_redis
     django_redis.client

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -24,7 +24,7 @@ herd.CACHE_HERD_TIMEOUT = 2
 
 
 def make_key(key, prefix, version):
-    return "{}#{}#{}".format(prefix, version, key)
+    return f"{prefix}#{version}#{key}"
 
 
 def reverse_key(key):

--- a/tests/test_hashring.py
+++ b/tests/test_hashring.py
@@ -8,10 +8,10 @@ class Node:
         self.id = id
 
     def __str__(self):
-        return "node:{}".format(self.id)
+        return f"node:{self.id}"
 
     def __repr__(self):
-        return "<Node {}>".format(self.id)
+        return f"<Node {self.id}>"
 
 
 class HashRingTest(unittest.TestCase):
@@ -26,12 +26,12 @@ class HashRingTest(unittest.TestCase):
     def test_hashring(self):
         ids = []
 
-        for key in ["test{}".format(x) for x in range(10)]:
+        for key in [f"test{x}" for x in range(10)]:
             node = self.ring.get_node(key)
             ids.append(node.id)
 
         self.assertEqual(ids, [0, 2, 1, 2, 2, 2, 2, 0, 1, 1])
 
     def test_hashring_brute_force(self):
-        for key in ("test{}".format(x) for x in range(10000)):
+        for key in (f"test{x}" for x in range(10000)):
             self.ring.get_node(key)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{35,36,37,38}-django22-redis{latest,master}
+    py{36,37,38}-django22-redis{latest,master}
     py{36,37,38}-django30-redis{latest,master}
     py{36,37,38}-django31-redis{latest,master}
     py{36,37,38}-djangomaster-redis{latest,master}
@@ -28,7 +28,7 @@ deps =
 [testenv:lint]
 basepython = python3
 commands =
-    black --target-version py35 --check --diff .
+    black --target-version py36 --check --diff .
     flake8
     isort --check-only --diff .
 deps =


### PR DESCRIPTION
EOL at the end of last month: https://devguide.python.org/devcycle/#end-of-life-branches

Helps free up a couple of slots in a busy CI, and allows to use new features of Python (hello f-strings!).

And upgrade Python syntax with https://github.com/asottile/pyupgrade using `--py36-plus`.
