### PR TITLE
Specified ACL login usage in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,9 +85,19 @@ django-redis uses the redis-py native URL notation for connection strings, it
 allows better interoperability and has a connection string in more "standard"
 way. Some examples:
 
-- ``redis://[:password]@localhost:6379/0``
-- ``rediss://[:password]@localhost:6379/0``
-- ``unix://[:password]@/path/to/socket.sock?db=0``
+- ``redis://[[username]:[password]]@localhost:6379/0``
+- ``rediss://[[username]:[password]]@localhost:6379/0``
+- ``unix://[[username]:[password]]@/path/to/socket.sock?db=0``
+
+When using [Redi's ACL](https://redis.io/topics/acl), you will need to add the
+username to the URL (and provide the password with the Cache "OPTIONS"; see below).
+The login for the user ``django`` would look like this:
+
+``redis://django@localhost:6379/0``
+
+When providing both username and password in the URL, this looks like this:
+
+``redis://django:mysecretpassword@localhost:6379/0``
 
 Three URL schemes are supported:
 

--- a/README.rst
+++ b/README.rst
@@ -89,16 +89,6 @@ way. Some examples:
 - ``rediss://[[username]:[password]]@localhost:6379/0``
 - ``unix://[[username]:[password]]@/path/to/socket.sock?db=0``
 
-When using [Redi's ACL](https://redis.io/topics/acl), you will need to add the
-username to the URL (and provide the password with the Cache "OPTIONS"; see below).
-The login for the user ``django`` would look like this:
-
-``redis://django@localhost:6379/0``
-
-When providing both username and password in the URL, this looks like this:
-
-``redis://django:mysecretpassword@localhost:6379/0``
-
 Three URL schemes are supported:
 
 - ``redis://``: creates a normal TCP socket connection
@@ -110,6 +100,37 @@ There are several ways to specify a database number:
 - A ``db`` querystring option, e.g. ``redis://localhost?db=0``
 - If using the ``redis://`` scheme, the path argument of the URL, e.g.
   ``redis://localhost/0``
+
+When using [Redi's ACL](https://redis.io/topics/acl), you will need to add the
+username to the URL (and provide the password with the Cache ``OPTIONS``).
+The login for the user ``django`` would look like this:
+
+.. code-block:: python
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://django@localhost:6379/0",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+                "PASSWORD": "mysecret"
+            }
+        }
+    }
+    
+An alternative would be write both username and password into the URL:
+
+.. code-block:: python
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://django:mysecret@localhost:6379/0",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            }
+        }
+    }
 
 In some circumstances the password you should use to connect Redis
 is not URL-safe, in this case you can escape it or just use the


### PR DESCRIPTION
It took me some digging in the redis-py source code (their README does not even hint this feature). Hence, I thought it may be useful to have it explicitely in the documentation for others