### PR TITLE
Use tox-gh-actions to reduce config effort.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
           - '3.8'
           - '3.9'
         django-version:
-          - '22'
-          - '30'
-          - '31'
+          - '2.2'
+          - '3.0'
+          - '3.1'
           - 'master'
         redis-version:
           - 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,43 +1,67 @@
 name: Test
 
-on:
-  - push
-  - pull_request
+on: [push, pull_request]
 
 jobs:
   build:
+    name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, Redis.py ${{ matrix.redis-version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
-        django:
-          - django22
-          - django30
-          - django31
-          - djangomaster
-        redis:
-          - redislatest
-          - redismaster
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+        django-version:
+          - '22'
+          - '30'
+          - '31'
+          - 'master'
+        redis-version:
+          - 'latest'
+          - 'master'
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Start Redis
-        uses: supercharge/redis-github-action@1.1.0
+    - name: Start Redis
+      uses: supercharge/redis-github-action@1.1.0
 
-      - name: Install dependencies
-        run: python -m pip install tox
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: Run tests
-        run: tox -e ${{ matrix.django }}-${{ matrix.redis }}
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key:
+          ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/tox.ini') }}
+        restore-keys: |
+          ${{ matrix.python-version }}-v1-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+
+    - name: Tox tests
+      run: |
+        tox -v
+      env:
+        DJANGO: ${{ matrix.django-version }}
+        REDIS: ${{ matrix.redis-version }}
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        name: Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,13 @@ Redis cache backend for Django
     :target: https://jazzband.co/
     :alt: Jazzband
 
-.. image:: https://travis-ci.org/jazzband/django-redis.svg?branch=master
-    :target: https://travis-ci.org/jazzband/django-redis
+.. image:: https://github.com/jazzband/django-redis/workflows/Test/badge.svg
+   :target: https://github.com/jazzband/django-redis/actions
+   :alt: GitHub Actions
+
+.. image:: https://codecov.io/gh/jazzband/django-redis/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/jazzband/django-redis
+   :alt: Coverage
 
 .. image:: https://img.shields.io/pypi/v/django-redis.svg?style=flat
     :target: https://pypi.org/project/django-redis/

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{36,37,38,39}-dj{22,30,31}-redis{latest,master}
+    py{36,37,38,39}-dj{22,30,31,master}-redis{latest,master}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,24 @@
 [tox]
 envlist =
     lint
-    py{36,37,38,39}-django22-redis{latest,master}
-    py{36,37,38,39}-django30-redis{latest,master}
-    py{36,37,38,39}-django31-redis{latest,master}
-    py{36,37,38,39}-djangomaster-redis{latest,master}
+    py{36,37,38,39}-dj{22,30,31}-redis{latest,master}
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38, lint
+    3.9: py39
+
+[gh-actions:env]
+DJANGO =
+    2.2: dj22
+    3.0: dj30
+    3.1: dj31
+    master: djmaster
+REDIS =
+    latest: redislatest
+    master: redismaster
 
 [testenv]
 commands =
@@ -17,10 +31,10 @@ commands =
   {envpython} -b -Wa tests/runtests-lz4.py
 
 deps =
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    dj22: Django>=2.2,<2.3
+    dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
+    djmaster: https://github.com/django/django/archive/master.tar.gz
     msgpack>=0.6.0
     redismaster: https://github.com/andymccurdy/redis-py/archive/master.tar.gz
     lz4>=0.15


### PR DESCRIPTION
This is related to the current effort to port all Jazzband projects to GitHub Actions and to use the same best practices to setup GHA as much as possible.