### PR TITLE
refactor: ensure close method is thread safe closes #491

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   - push
-
+  - pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   - push
-
+  - pull_request
 jobs:
   build:
     name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, Redis.py ${{ matrix.redis-version }})

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -567,10 +567,8 @@ class DefaultClient:
 
     def close(self, **kwargs):
         if getattr(settings, "DJANGO_REDIS_CLOSE_CONNECTION", False):
-            for i in range(len(self._clients)):
-                for c in self._clients[i].connection_pool._available_connections:
-                    c.disconnect()
-                self._clients[i] = None
+            for client in self._clients:
+                client.connection_pool.disconnect()
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, client=None):
         """

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -569,7 +569,8 @@ class DefaultClient:
         if getattr(settings, "DJANGO_REDIS_CLOSE_CONNECTION", False):
             for i in range(len(self._clients)):
                 client = self._clients[i]
-                self._disconnect_client(client)
+                if client is not None:
+                    client.connection_pool.disconnect()
                 self._clients[i] = None
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, client=None):
@@ -590,9 +591,3 @@ class DefaultClient:
             # Convert to milliseconds
             timeout = int(timeout * 1000)
             return bool(client.pexpire(key, timeout))
-
-    @staticmethod
-    def _disconnect_client(client):
-        if client is not None:
-            for connection in client.connection_pool._available_connections:
-                connection.disconnect()

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -572,7 +572,7 @@ class DefaultClient:
                 if client is not None:
                     for connection in client.connection_pool._available_connections:
                         connection.disconnect()
-                self._clients[i] is None
+                self._clients[i] = None
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, client=None):
         """

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -568,9 +568,11 @@ class DefaultClient:
     def close(self, **kwargs):
         if getattr(settings, "DJANGO_REDIS_CLOSE_CONNECTION", False):
             for i in range(len(self._clients)):
-                for c in self._clients[i].connection_pool._available_connections:
-                    c.disconnect()
-                self._clients[i] = None
+                client = self._clients[i]
+                if client is not None:
+                    for connection in client.connection_pool._available_connections:
+                        connection.disconnect()
+                self._clients[i] is None
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, client=None):
         """

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -568,9 +568,8 @@ class DefaultClient:
     def close(self, **kwargs):
         if getattr(settings, "DJANGO_REDIS_CLOSE_CONNECTION", False):
             for i in range(len(self._clients)):
-                client = self._clients[i]
-                if client is not None:
-                    client.connection_pool.disconnect()
+                for c in self._clients[i].connection_pool._available_connections:
+                    c.disconnect()
                 self._clients[i] = None
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, client=None):

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -569,9 +569,7 @@ class DefaultClient:
         if getattr(settings, "DJANGO_REDIS_CLOSE_CONNECTION", False):
             for i in range(len(self._clients)):
                 client = self._clients[i]
-                if client is not None:
-                    for connection in client.connection_pool._available_connections:
-                        connection.disconnect()
+                self._disconnect_client(client)
                 self._clients[i] = None
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, client=None):
@@ -592,3 +590,9 @@ class DefaultClient:
             # Convert to milliseconds
             timeout = int(timeout * 1000)
             return bool(client.pexpire(key, timeout))
+
+    @staticmethod
+    def _disconnect_client(client):
+        if client is not None:
+            for connection in client.connection_pool._available_connections:
+                connection.disconnect()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -703,11 +703,9 @@ class DjangoRedisCacheTests(unittest.TestCase):
 
 
 class DjangoRedisCacheTestsWithClose(DjangoRedisCacheTests):
+    @override_settings(DJANGO_REDIS_CLOSE_CONNECTION=True)
     def test_close(self):
-        with override_settings(
-            CACHE=settings.CACHES, DJANGO_REDIS_CLOSE_CONNECTION=True
-        ):
-            super().test_close()
+        super().test_close()
 
 
 class DjangoRedisCacheWithCloseAndBlockingConnectionPool(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -559,6 +559,7 @@ class DjangoRedisCacheTests(unittest.TestCase):
             "*foo-a*", itersize=expected_count
         )
 
+    @override_settings(DJANGO_REDIS_CLOSE_CONNECTION=True)
     def test_close(self):
         self.cache.set("f", "1")
         self.cache.close()
@@ -699,12 +700,6 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.assertIs(result, True)
         time.sleep(2)
         self.assertEqual(self.cache.get("test_key"), "foo")
-
-
-class DjangoRedisCacheTestsWithClose(DjangoRedisCacheTests):
-    @override_settings(DJANGO_REDIS_CLOSE_CONNECTION=True)
-    def test_close(self):
-        super().test_close()
 
 
 class DjangoOmitExceptionsTests(unittest.TestCase):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -560,9 +560,8 @@ class DjangoRedisCacheTests(unittest.TestCase):
         )
 
     def test_close(self):
-        cache = caches["default"]
-        cache.set("f", "1")
-        cache.close()
+        self.cache.set("f", "1")
+        self.cache.close()
 
     def test_ttl(self):
         cache = caches["default"]
@@ -706,29 +705,6 @@ class DjangoRedisCacheTestsWithClose(DjangoRedisCacheTests):
     @override_settings(DJANGO_REDIS_CLOSE_CONNECTION=True)
     def test_close(self):
         super().test_close()
-
-
-class DjangoRedisCacheWithCloseAndBlockingConnectionPool(
-    DjangoRedisCacheTestsWithClose
-):
-    def setUp(self):
-        cache_settings = copy.deepcopy(settings.CACHES)
-        cache_settings["default"]["OPTIONS"][
-            "CONNECTION_POOL_CLASS"
-        ] = "redis.connection.BlockingConnectionPool"
-        cache_settings["default"]["OPTIONS"]["CONNECTION_POOL_KWARGS"] = {
-            "timeout": None,
-            "max_connections": 100,
-        }
-        cm = override_settings(
-            CACHES=cache_settings, DJANGO_REDIS_CLOSE_CONNECTION=True
-        )
-        cm.enable()
-        self.addCleanup(cm.disable)
-        super().setUp()
-
-    def test_set_call_empty_pipeline(self):
-        self.skipTest("Unreliable with blocking connection pool")
 
 
 class DjangoOmitExceptionsTests(unittest.TestCase):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -720,8 +720,9 @@ class DjangoRedisCacheWithCloseAndBlockingConnectionPool(
             "timeout": None,
             "max_connections": 100,
         }
-        cm = override_settings(CACHES=cache_settings,
-                               DJANGO_REDIS_CLOSE_CONNECTION=True)
+        cm = override_settings(
+            CACHES=cache_settings, DJANGO_REDIS_CLOSE_CONNECTION=True
+        )
         cm.enable()
         self.addCleanup(cm.disable)
         super().setUp()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -720,7 +720,8 @@ class DjangoRedisCacheWithCloseAndBlockingConnectionPool(
             "timeout": None,
             "max_connections": 100,
         }
-        cm = override_settings(CACHES=cache_settings)
+        cm = override_settings(CACHES=cache_settings,
+                               DJANGO_REDIS_CLOSE_CONNECTION=True)
         cm.enable()
         self.addCleanup(cm.disable)
         super().setUp()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -288,7 +288,6 @@ class DjangoRedisCacheTests(unittest.TestCase):
 
         res = cache.get("add_key")
         self.assertEqual(res, "Initial value")
-        cache.delete("other_key")
         res = self.cache.add("other_key", "New value")
         self.assertIs(res, True)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -727,6 +727,9 @@ class DjangoRedisCacheWithCloseAndBlockingConnectionPool(
         self.addCleanup(cm.disable)
         super().setUp()
 
+    def test_set_call_empty_pipeline(self):
+        self.skipTest("Unreliable with blocking connection pool")
+
 
 class DjangoOmitExceptionsTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -26,4 +26,3 @@ CACHES = {
 }
 
 INSTALLED_APPS = ["django.contrib.sessions"]
-DJANGO_REDIS_CLOSE_CONNECTION = False

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -5,7 +5,6 @@ CACHES = {
         "LOCATION": ["redis://127.0.0.1:6379?db=1", "redis://127.0.0.1:6379?db=1"],
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "CONNECTION_POOL_CLASS": "redis.connection.BlockingConnectionPool",
         },
     },
     "doesnotexist": {


### PR DESCRIPTION
call the method disconnect of ConnectionPool instead of modifying protected attribute