### PR TITLE
Fix clear shard client

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Todd Boland / boland <https://github.com/boland>
 David Zderic / dzderic <https://github.com/dzderic>
 Kirill Zaitsev / teferi <https://github.com/teferi>
 Jon Dufresne <https://github.com/jdufresne>
+Anès Foufa <https://github.com/AnesFoufa>

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -277,3 +277,7 @@ class ShardClient(DefaultClient):
             client = self.get_server(key)
 
         return super().touch(key=key, timeout=timeout, version=version, client=client)
+
+    def clear(self, client=None):
+        for _, connection in self._serverdict.items():
+            connection.flushdb()

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -279,5 +279,5 @@ class ShardClient(DefaultClient):
         return super().touch(key=key, timeout=timeout, version=version, client=client)
 
     def clear(self, client=None):
-        for _, connection in self._serverdict.items():
+        for connection in self._serverdict.values():
             connection.flushdb()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -55,8 +55,10 @@ class DjangoRedisCacheTestEscapePrefix(unittest.TestCase):
         self.addCleanup(cm.disable)
 
         self.cache = caches["default"]
-        self.cache.clear()
         self.other = caches["with_prefix"]
+
+    def tearDown(self):
+        self.cache.clear()
         self.other.clear()
 
     def test_delete_pattern(self):
@@ -92,6 +94,8 @@ class DjangoRedisCacheTestCustomKeyFunction(unittest.TestCase):
         self.addCleanup(cm.disable)
 
         self.cache = caches["default"]
+
+    def tearDown(self):
         self.cache.clear()
 
     def test_custom_key_function(self):
@@ -116,6 +120,8 @@ class DjangoRedisCacheTestCustomKeyFunction(unittest.TestCase):
 class DjangoRedisCacheTests(unittest.TestCase):
     def setUp(self):
         self.cache = cache
+
+    def tearDown(self):
         self.cache.clear()
 
     def test_setnx(self):
@@ -1212,7 +1218,7 @@ class TestClearClient(unittest.TestCase):
     key = "foo"
     value = "bar"
 
-    def setUp(self) -> None:
+    def setUp(self):
         self.cache = caches[self.cache_name]
 
     def test_clear(self):
@@ -1222,3 +1228,9 @@ class TestClearClient(unittest.TestCase):
         self.cache.clear()
         value_from_cache_after_clear = self.cache.get(self.value)
         self.assertIsNone(value_from_cache_after_clear)
+
+
+class TestClearClientWithPrefix(TestClearClient):
+    cache_name = "with_prefix"
+    key = "baz"
+    value = "spam"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -55,15 +55,9 @@ class DjangoRedisCacheTestEscapePrefix(unittest.TestCase):
         self.addCleanup(cm.disable)
 
         self.cache = caches["default"]
-        try:
-            self.cache.clear()
-        except Exception:
-            pass
+        self.cache.clear()
         self.other = caches["with_prefix"]
-        try:
-            self.other.clear()
-        except Exception:
-            pass
+        self.other.clear()
 
     def test_delete_pattern(self):
         self.cache.set("a", "1")
@@ -98,10 +92,7 @@ class DjangoRedisCacheTestCustomKeyFunction(unittest.TestCase):
         self.addCleanup(cm.disable)
 
         self.cache = caches["default"]
-        try:
-            self.cache.clear()
-        except Exception:
-            pass
+        self.cache.clear()
 
     def test_custom_key_function(self):
         if isinstance(self.cache.client, ShardClient):
@@ -125,11 +116,7 @@ class DjangoRedisCacheTestCustomKeyFunction(unittest.TestCase):
 class DjangoRedisCacheTests(unittest.TestCase):
     def setUp(self):
         self.cache = cache
-
-        try:
-            self.cache.clear()
-        except Exception:
-            pass
+        self.cache.clear()
 
     def test_setnx(self):
         # we should ensure there is no test_key_nx in redis

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -694,6 +694,14 @@ class DjangoRedisCacheTests(unittest.TestCase):
         time.sleep(2)
         self.assertEqual(self.cache.get("test_key"), "foo")
 
+    def test_clear(self):
+        self.cache.set("foo", "bar")
+        value_from_cache = self.cache.get("foo")
+        self.assertEqual(value_from_cache, "bar")
+        self.cache.clear()
+        value_from_cache_after_clear = self.cache.get("foo")
+        self.assertIsNone(value_from_cache_after_clear)
+
 
 class DjangoOmitExceptionsTests(unittest.TestCase):
     def setUp(self):
@@ -1211,26 +1219,3 @@ class TestShardClient(unittest.TestCase):
         client.delete_pattern(pattern="foo*")
 
         connection.delete.assert_called_once_with(*connection.scan_iter.return_value)
-
-
-class TestClearClient(unittest.TestCase):
-    cache_name = "default"
-    key = "foo"
-    value = "bar"
-
-    def setUp(self):
-        self.cache = caches[self.cache_name]
-
-    def test_clear(self):
-        self.cache.set(self.key, self.value)
-        value_from_cache = self.cache.get(self.key)
-        self.assertEqual(value_from_cache, self.value)
-        self.cache.clear()
-        value_from_cache_after_clear = self.cache.get(self.value)
-        self.assertIsNone(value_from_cache_after_clear)
-
-
-class TestClearClientWithPrefix(TestClearClient):
-    cache_name = "with_prefix"
-    key = "baz"
-    value = "spam"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1218,3 +1218,20 @@ class TestShardClient(unittest.TestCase):
         client.delete_pattern(pattern="foo*")
 
         connection.delete.assert_called_once_with(*connection.scan_iter.return_value)
+
+
+class TestClearClient(unittest.TestCase):
+    cache_name = "default"
+    key = "foo"
+    value = "bar"
+
+    def setUp(self) -> None:
+        self.cache = caches[self.cache_name]
+
+    def test_clear(self):
+        self.cache.set(self.key, self.value)
+        value_from_cache = self.cache.get(self.key)
+        self.assertEqual(value_from_cache, self.value)
+        self.cache.clear()
+        value_from_cache_after_clear = self.cache.get(self.value)
+        self.assertIsNone(value_from_cache_after_clear)


### PR DESCRIPTION
This pull request tests the method clear fir all the clients. This method raises an NotImplementedError for ShardClient as seen here
https://github.com/AnesFoufa/django-redis/actions/runs/484855381
So I added an basic implementation that passes the test.