### PR TITLE
Added exclusion of python 3.6 and 3.7 with django master from matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,11 @@ jobs:
         redis-version:
           - 'latest'
           - 'master'
+        exclude:
+          - django-version: 'master'
+            python-version: '3.6'
+          - django-version: 'master'
+            python-version: '3.7'
 
     services:
       redis:


### PR DESCRIPTION
Removed python 3.6 and 3.7 from matrix with django master because django will be requiring 3.8 from now on