### PR TITLE
Rename Django's dev branch to main.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,14 @@ jobs:
           - '2.2'
           - '3.0'
           - '3.1'
-          - 'master'
+          - 'main'
         redis-version:
           - 'latest'
           - 'master'
         exclude:
-          - django-version: 'master'
+          - django-version: 'main'
             python-version: '3.6'
-          - django-version: 'master'
+          - django-version: 'main'
             python-version: '3.7'
 
     services:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -785,7 +785,7 @@ class DjangoOmitExceptionsPriority2Tests(unittest.TestCase):
 
 
 # Copied from Django's sessions test suite. Keep in sync with upstream.
-# https://github.com/django/django/blob/master/tests/sessions_tests/tests.py
+# https://github.com/django/django/blob/main/tests/sessions_tests/tests.py
 class SessionTestsMixin:
     # This does not inherit from TestCase to avoid any tests being run with this
     # class, which wouldn't work, and to allow different TestCase subclasses to

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     lint
-    py{36,37,38,39}-dj{22,30,31,main}-redis{latest,master}
+    py{36,37,38,39}-dj{22,30,31}-redis{latest,master}
+    py{38,39}-djmain-redis{latest,master}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{36,37,38,39}-dj{22,30,31,master}-redis{latest,master}
+    py{36,37,38,39}-dj{22,30,31,main}-redis{latest,master}
 
 [gh-actions]
 python =
@@ -15,7 +15,7 @@ DJANGO =
     2.2: dj22
     3.0: dj30
     3.1: dj31
-    master: djmaster
+    main: djmain
 REDIS =
     latest: redislatest
     master: redismaster
@@ -34,7 +34,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
-    djmaster: https://github.com/django/django/archive/master.tar.gz
+    djmain: https://github.com/django/django/archive/main.tar.gz
     msgpack>=0.6.0
     redismaster: https://github.com/andymccurdy/redis-py/archive/master.tar.gz
     lz4>=0.15


### PR DESCRIPTION
As discussed in https://groups.google.com/g/django-developers/c/tctDuKUGosc/ and implemented in https://github.com/django/django/pull/14048