### PR TITLE
[Update] expire and ttl are replaced by pexipre and pttl to provide milli-seconds precision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Date: TBD
 - added ``.expire_at()`` method
 - fixed ``.incr()`` when ttl is ``None`` or when the number is larger than 64 bit
 - fixed ``.incr_version()`` when ttl is ``None``
+- added ``.pttl()`` method to the clients to support milli-second precision for
+  ttl of a key
+- added ``.pexpire()`` method to the clients to support milli-second precision
+  for setting expiry of a key
 
 Version 4.12.1
 --------------

--- a/README.rst
+++ b/README.rst
@@ -350,9 +350,11 @@ It returns:
     >>> from django.core.cache import cache
     >>> cache.set("foo", "value", timeout=25)
     >>> cache.ttl("foo")
-    25
+    25.0
     >>> cache.ttl("not-existent")
-    0
+    0.0
+
+Note: ttl previously returned an int. Now it returns a float.
 
 Expire & Persist
 ~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -350,11 +350,21 @@ It returns:
     >>> from django.core.cache import cache
     >>> cache.set("foo", "value", timeout=25)
     >>> cache.ttl("foo")
-    25.0
+    25
     >>> cache.ttl("not-existent")
-    0.0
+    0
 
-Note: ttl previously returned an int. Now it returns a float.
+With Redis, you can access to ttl of any stored key in milliseconds, for it, django-redis
+exposes ``pttl`` function.
+
+.. code-block:: pycon
+
+    >>> from django.core.cache import cache
+    >>> cache.set("foo", "value", timeout=25)
+    >>> cache.pttl("foo")
+    25000
+    >>> cache.pttl("not-existent")
+    0
 
 Expire & Persist
 ~~~~~~~~~~~~~~~~
@@ -377,6 +387,14 @@ specify a new expiration timeout using the ``persist`` and ``expire`` methods:
     >>> cache.expire("foo", timeout=5)
     >>> cache.ttl("foo")
     5
+
+The ``pexpire`` method can be used to provide millisecond precision:
+.. code-block:: pycon
+
+    >>> cache.set("foo", "bar", timeout=22)
+    >>> cache.pexpire("foo", timeout=5500)
+    >>> cache.pttl("foo")
+    5500
 
 Locks
 ~~~~~

--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -149,6 +149,10 @@ class RedisCache(BaseCache):
         return self.client.ttl(*args, **kwargs)
 
     @omit_exception
+    def pttl(self, *args, **kwargs):
+        return self.client.pttl(*args, **kwargs)
+
+    @omit_exception
     def persist(self, *args, **kwargs):
         return self.client.persist(*args, **kwargs)
 
@@ -159,6 +163,9 @@ class RedisCache(BaseCache):
     @omit_exception
     def expire_at(self, *args, **kwargs):
         return self.client.expire_at(*args, **kwargs)
+
+    def pexpire(self, *args, **kwargs):
+        return self.client.pexpire(*args, **kwargs)
 
     @omit_exception
     def lock(self, *args, **kwargs):

--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -164,6 +164,7 @@ class RedisCache(BaseCache):
     def expire_at(self, *args, **kwargs):
         return self.client.expire_at(*args, **kwargs)
 
+    @omit_exception
     def pexpire(self, *args, **kwargs):
         return self.client.pexpire(*args, **kwargs)
 

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -581,7 +581,8 @@ class DefaultClient:
         """
         Executes TTL redis command and return the "time-to-live" of specified key.
         If key is a non volatile key, it returns None.
-        Warning: ttl previously returned an int. Now it returns a float.
+        Note: ttl previously return the number of seconds in an integer. Now it
+        returns the number of seconds with decimals which represent milliseconds in a float.
         """
         if client is None:
             client = self.get_client(write=False)

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -581,8 +581,8 @@ class DefaultClient:
         """
         Executes TTL redis command and return the "time-to-live" of specified key.
         If key is a non volatile key, it returns None.
-        Note: ttl previously return the number of seconds in an integer. Now it
-        returns the number of seconds with decimals which represent milliseconds in a float.
+        Note: ttl previously return the number of seconds in an integer. Now it returns
+        the number of seconds with decimals which represent milliseconds in a float.
         """
         if client is None:
             client = self.get_client(write=False)

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -592,7 +592,7 @@ class DefaultClient:
         t = client.pttl(key)
 
         if t >= 0:
-            return t / 1000
+            return round(t / 1000, 3)
         elif t == -1:
             return None
         elif t == -2:

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -288,7 +288,8 @@ class DefaultClient:
         key = self.make_key(key, version=version)
 
         if client.exists(key):
-            client.expire(key, timeout)
+            timeout = int(timeout * 1000)
+            client.pexpire(key, timeout)
 
     def expire_at(
         self,
@@ -588,10 +589,10 @@ class DefaultClient:
         if not client.exists(key):
             return 0
 
-        t = client.ttl(key)
+        t = client.pttl(key)
 
         if t >= 0:
-            return t
+            return t / 1000
         elif t == -1:
             return None
         elif t == -2:

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -581,6 +581,7 @@ class DefaultClient:
         """
         Executes TTL redis command and return the "time-to-live" of specified key.
         If key is a non volatile key, it returns None.
+        Warning: ttl previously returned an int. Now it returns a float.
         """
         if client is None:
             client = self.get_client(write=False)

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -138,6 +138,18 @@ class ShardClient(DefaultClient):
 
         return super().ttl(key=key, version=version, client=client)
 
+    def pttl(self, key, version=None, client=None):
+        """
+        Executes PTTL redis command and return the "time-to-live" of specified key
+        in milliseconds. If key is a non volatile key, it returns None.
+        """
+
+        if client is None:
+            key = self.make_key(key, version=version)
+            client = self.get_server(key)
+
+        return super().pttl(key=key, version=version, client=client)
+
     def persist(self, key, version=None, client=None):
         if client is None:
             key = self.make_key(key, version=version)
@@ -151,6 +163,13 @@ class ShardClient(DefaultClient):
             client = self.get_server(key)
 
         return super().expire(key=key, timeout=timeout, version=version, client=client)
+
+    def pexpire(self, key, timeout, version=None, client=None):
+        if client is None:
+            key = self.make_key(key, version=version)
+            client = self.get_server(key)
+
+        return super().pexpire(key=key, timeout=timeout, version=version, client=client)
 
     def expire_at(self, key, when: Union[datetime, int], version=None, client=None):
         """

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -653,21 +653,21 @@ class DjangoRedisCacheTests(unittest.TestCase):
         # Test pttl
         self.cache.set("foo", "bar", 10)
         ttl = self.cache.pttl("foo")
-        
-        # delta is set to 1 as precision error causes tests to fail
+
+        # delta is set to 10 as precision error causes tests to fail
         if isinstance(self.cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 12000, delta=1)
+            self.assertAlmostEqual(ttl, 12000, delta=10)
         else:
-            self.assertAlmostEqual(ttl, 10000, delta=1)
+            self.assertAlmostEqual(ttl, 10000, delta=10)
 
         # Test pttl with float value
         self.cache.set("foo", "bar", 5.5)
         ttl = self.cache.pttl("foo")
 
         if isinstance(cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 7500, delta=1)
+            self.assertAlmostEqual(ttl, 7500, delta=10)
         else:
-            self.assertAlmostEqual(ttl, 5500, delta=1)
+            self.assertAlmostEqual(ttl, 5500, delta=10)
 
         # Test pttl None
         self.cache.set("foo", "foo", timeout=None)
@@ -700,8 +700,8 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.cache.set("foo", "bar", timeout=None)
         self.cache.pexpire("foo", 20500)
         ttl = self.cache.pttl("foo")
-        # delta is set to 1 as precision error causes tests to fail
-        self.assertAlmostEqual(ttl, 20500, delta=1)
+        # delta is set to 10 as precision error causes tests to fail
+        self.assertAlmostEqual(ttl, 20500, delta=10)
 
     def test_expire_at(self):
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -630,9 +630,18 @@ class DjangoRedisCacheTests(unittest.TestCase):
         ttl = self.cache.ttl("foo")
 
         if isinstance(cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 12, delta=0.001)
+            self.assertAlmostEqual(ttl, 12, delta=0.01)
         else:
-            self.assertAlmostEqual(ttl, 10, delta=0.001)
+            self.assertAlmostEqual(ttl, 10, delta=0.01)
+
+        # Test ttl with float value
+        cache.set("foo", "bar", 5.5)
+        ttl = cache.ttl("foo")
+
+        if isinstance(cache.client, herd.HerdClient):
+            self.assertAlmostEqual(ttl, 7.5, delta=0.01)
+        else:
+            self.assertAlmostEqual(ttl, 5.5, delta=0.01)
 
         # Test ttl None
         self.cache.set("foo", "foo", timeout=None)
@@ -659,7 +668,7 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.cache.set("foo", "bar", timeout=None)
         self.cache.expire("foo", 20)
         ttl = self.cache.ttl("foo")
-        self.assertAlmostEqual(ttl, 20)
+        self.assertAlmostEqual(ttl, 20, delta=0.01)
 
     def test_expire_at(self):
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -630,9 +630,9 @@ class DjangoRedisCacheTests(unittest.TestCase):
         ttl = self.cache.ttl("foo")
 
         if isinstance(cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 12)
+            self.assertAlmostEqual(ttl, 12, delta=0.001)
         else:
-            self.assertAlmostEqual(ttl, 10)
+            self.assertAlmostEqual(ttl, 10, delta=0.001)
 
         # Test ttl None
         self.cache.set("foo", "foo", timeout=None)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -653,7 +653,8 @@ class DjangoRedisCacheTests(unittest.TestCase):
         # Test pttl
         self.cache.set("foo", "bar", 10)
         ttl = self.cache.pttl("foo")
-
+        
+        # delta is set to 1 as precision error causes tests to fail
         if isinstance(self.cache.client, herd.HerdClient):
             self.assertAlmostEqual(ttl, 12000, delta=1)
         else:
@@ -699,6 +700,7 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.cache.set("foo", "bar", timeout=None)
         self.cache.pexpire("foo", 20500)
         ttl = self.cache.pttl("foo")
+        # delta is set to 1 as precision error causes tests to fail
         self.assertAlmostEqual(ttl, 20500, delta=1)
 
     def test_expire_at(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -629,45 +629,10 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.cache.set("foo", "bar", 10)
         ttl = self.cache.ttl("foo")
 
-        if isinstance(cache.client, herd.HerdClient):
+        if isinstance(self.cache.client, herd.HerdClient):
             self.assertAlmostEqual(ttl, 12)
         else:
             self.assertAlmostEqual(ttl, 10)
-
-        # Test ttl None
-        cache.set("foo", "foo", timeout=None)
-        ttl = cache.ttl("foo")
-        self.assertIsNone(ttl)
-
-        # Test ttl with expired key
-        cache.set("foo", "foo", timeout=-1)
-        ttl = cache.ttl("foo")
-        self.assertEqual(ttl, 0)
-
-        # Test ttl with not existent key
-        ttl = cache.ttl("not-existent-key")
-        self.assertEqual(ttl, 0)
-
-    def test_pttl(self):
-        cache = caches["default"]
-
-        # Test ttl
-        cache.set("foo", "bar", 10)
-        ttl = cache.pttl("foo")
-
-        if isinstance(cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 12000, delta=1)
-        else:
-            self.assertAlmostEqual(ttl, 10000, delta=1)
-
-        # Test ttl with float value
-        cache.set("foo", "bar", 5.5)
-        ttl = cache.pttl("foo")
-
-        if isinstance(cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 7500, delta=1)
-        else:
-            self.assertAlmostEqual(ttl, 5500, delta=1)
 
         # Test ttl None
         self.cache.set("foo", "foo", timeout=None)
@@ -681,6 +646,40 @@ class DjangoRedisCacheTests(unittest.TestCase):
 
         # Test ttl with not existent key
         ttl = self.cache.ttl("not-existent-key")
+        self.assertEqual(ttl, 0)
+
+    def test_pttl(self):
+
+        # Test pttl
+        self.cache.set("foo", "bar", 10)
+        ttl = self.cache.pttl("foo")
+
+        if isinstance(self.cache.client, herd.HerdClient):
+            self.assertAlmostEqual(ttl, 12000, delta=1)
+        else:
+            self.assertAlmostEqual(ttl, 10000, delta=1)
+
+        # Test pttl with float value
+        self.cache.set("foo", "bar", 5.5)
+        ttl = self.cache.pttl("foo")
+
+        if isinstance(cache.client, herd.HerdClient):
+            self.assertAlmostEqual(ttl, 7500, delta=1)
+        else:
+            self.assertAlmostEqual(ttl, 5500, delta=1)
+
+        # Test pttl None
+        self.cache.set("foo", "foo", timeout=None)
+        ttl = self.cache.pttl("foo")
+        self.assertIsNone(ttl)
+
+        # Test pttl with expired key
+        self.cache.set("foo", "foo", timeout=-1)
+        ttl = self.cache.pttl("foo")
+        self.assertEqual(ttl, 0)
+
+        # Test pttl with not existent key
+        ttl = self.cache.pttl("not-existent-key")
         self.assertEqual(ttl, 0)
 
     def test_persist(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -656,18 +656,18 @@ class DjangoRedisCacheTests(unittest.TestCase):
         ttl = cache.pttl("foo")
 
         if isinstance(cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 12000)
+            self.assertAlmostEqual(ttl, 12000, delta=1)
         else:
-            self.assertAlmostEqual(ttl, 10000)
+            self.assertAlmostEqual(ttl, 10000, delta=1)
 
         # Test ttl with float value
         cache.set("foo", "bar", 5.5)
         ttl = cache.pttl("foo")
 
         if isinstance(cache.client, herd.HerdClient):
-            self.assertAlmostEqual(ttl, 7500)
+            self.assertAlmostEqual(ttl, 7500, delta=1)
         else:
-            self.assertAlmostEqual(ttl, 5500)
+            self.assertAlmostEqual(ttl, 5500, delta=1)
 
         # Test ttl None
         self.cache.set("foo", "foo", timeout=None)
@@ -700,7 +700,7 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.cache.set("foo", "bar", timeout=None)
         self.cache.pexpire("foo", 20500)
         ttl = self.cache.pttl("foo")
-        self.assertAlmostEqual(ttl, 20500)
+        self.assertAlmostEqual(ttl, 20500, delta=1)
 
     def test_expire_at(self):
 


### PR DESCRIPTION
Fixes #333 
Fixes #505 