### PR TITLE
fix stray markdown in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,6 @@ Redis cache backend for Django
     :target: https://jazzband.co/
     :alt: Jazzband
 
-[![Test]()]()
-
 .. image:: https://github.com/jazzband/django-redis/actions/workflows/ci.yml/badge.svg
    :target: https://github.com/jazzband/django-redis/actions/workflows/ci.yml
    :alt: GitHub Actions


### PR DESCRIPTION
Accidentally introduced in #506 when copying GitHub's "Create Status Badge" markup.