### PR TITLE
update hashring tests as an example of how to convert to pytest tests

### DIFF
--- a/tests/test_hashring.py
+++ b/tests/test_hashring.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from django_redis.hash_ring import HashRing
 
@@ -14,24 +14,21 @@ class Node:
         return f"<Node {self.id}>"
 
 
-class HashRingTest(unittest.TestCase):
-    def setUp(self):
-        self.node0 = Node(0)
-        self.node1 = Node(1)
-        self.node2 = Node(2)
+@pytest.fixture
+def hash_ring():
+    return HashRing([Node(i) for i in range(3)])
 
-        self.nodes = [self.node0, self.node1, self.node2]
-        self.ring = HashRing(self.nodes)
 
-    def test_hashring(self):
-        ids = []
+def test_hashring(hash_ring):
+    ids = []
 
-        for key in [f"test{x}" for x in range(10)]:
-            node = self.ring.get_node(key)
-            ids.append(node.id)
+    for key in [f"test{x}" for x in range(10)]:
+        node = hash_ring.get_node(key)
+        ids.append(node.id)
 
-        self.assertEqual(ids, [0, 2, 1, 2, 2, 2, 2, 0, 1, 1])
+    assert ids == [0, 2, 1, 2, 2, 2, 2, 0, 1, 1]
 
-    def test_hashring_brute_force(self):
-        for key in (f"test{x}" for x in range(10000)):
-            self.ring.get_node(key)
+
+def test_hashring_brute_force(hash_ring):
+    for key in (f"test{x}" for x in range(10000)):
+        assert hash_ring.get_node(key)


### PR DESCRIPTION
This PR has been annotated with a brief description how to convert unittest tests to pytest test cases for #521.