### PR TITLE
Fixed incr when number is larger than 64 bit and has no timeout

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -507,13 +507,7 @@ class DefaultClient:
                 # In this situations redis will throw ResponseError
 
                 # try to keep TTL of key
-
-                timeout = client.ttl(key)
-
-                # returns -1 if the key does exist and does not have expiration
-                # keeping it that way by setting timeout to None
-                if timeout == -1:
-                    timeout = None
+                timeout = self.ttl(key, version=version, client=client)
 
                 # returns -2 if the key does not exist
                 # means, that key have expired

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -509,6 +509,12 @@ class DefaultClient:
                 # try to keep TTL of key
 
                 timeout = client.ttl(key)
+
+                # returns -1 if the key does exist and does not have expiration
+                # keeping it that way by setting timeout to None
+                if timeout == -1:
+                    timeout = None
+
                 # returns -2 if the key does not exist
                 # means, that key have expired
                 if timeout == -2:
@@ -673,7 +679,7 @@ class DefaultClient:
             self.do_close_clients()
 
     def do_close_clients(self):
-        """ default implementation: Override in custom client """
+        """default implementation: Override in custom client"""
         num_clients = len(self._clients)
         for idx in range(num_clients):
             self.disconnect(index=idx)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -428,6 +428,37 @@ class DjangoRedisCacheTests(unittest.TestCase):
         res = self.cache.get("num")
         self.assertEqual(res, 5)
 
+    def test_incr_no_timeout(self):
+        if isinstance(self.cache.client, herd.HerdClient):
+            self.skipTest("HerdClient doesn't support incr")
+
+        self.cache.set("num", 1, timeout=None)
+
+        self.cache.incr("num")
+        res = self.cache.get("num")
+        self.assertEqual(res, 2)
+
+        self.cache.incr("num", 10)
+        res = self.cache.get("num")
+        self.assertEqual(res, 12)
+
+        # max 64 bit signed int
+        self.cache.set("num", 9223372036854775807, timeout=None)
+
+        self.cache.incr("num")
+        res = self.cache.get("num")
+        self.assertEqual(res, 9223372036854775808)
+
+        self.cache.incr("num", 2)
+        res = self.cache.get("num")
+        self.assertEqual(res, 9223372036854775810)
+
+        self.cache.set("num", 3, timeout=None)
+
+        self.cache.incr("num", 2)
+        res = self.cache.get("num")
+        self.assertEqual(res, 5)
+
     def test_incr_error(self):
         if isinstance(self.cache.client, herd.HerdClient):
             self.skipTest("HerdClient doesn't support incr")


### PR DESCRIPTION
Very similar to #523 it is applied to the `.incr` and consequentially to the `.decr` method.

Probably there will be the same mypy coverage issue as the other PR

fixes: #499