### PR TITLE
tweak codecov.io settings

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,8 @@
 coverage:
+  # small changes should not fail coverage
+  precision: 1
+  round: up
+
   status:
     project:
       default:


### PR DESCRIPTION
I believe this should be sufficient to make mypy less sensitive (it will do both status checks, but I think this is probably fine for either). We can also set a [threshold](https://docs.codecov.io/docs/commit-status#threshold) if you think we should allow mypy coverage dropping @WisdomPill (that one is per check).