### PR TITLE
Draft: Fix test failure caused by django deprecation

### DIFF
--- a/tests/settings/sqlite.py
+++ b/tests/settings/sqlite.py
@@ -1,4 +1,6 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
+
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",

--- a/tests/settings/sqlite_herd.py
+++ b/tests/settings/sqlite_herd.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 CACHES = {
     "default": {

--- a/tests/settings/sqlite_json.py
+++ b/tests/settings/sqlite_json.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 CACHES = {
     "default": {

--- a/tests/settings/sqlite_lz4.py
+++ b/tests/settings/sqlite_lz4.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 CACHES = {
     "default": {

--- a/tests/settings/sqlite_msgpack.py
+++ b/tests/settings/sqlite_msgpack.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 CACHES = {
     "default": {

--- a/tests/settings/sqlite_sentinel.py
+++ b/tests/settings/sqlite_sentinel.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 DJANGO_REDIS_CONNECTION_FACTORY = "django_redis.pool.SentinelConnectionFactory"
 

--- a/tests/settings/sqlite_sharding.py
+++ b/tests/settings/sqlite_sharding.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 CACHES = {
     "default": {

--- a/tests/settings/sqlite_usock.py
+++ b/tests/settings/sqlite_usock.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 CACHES = {
     "default": {

--- a/tests/settings/sqlite_zlib.py
+++ b/tests/settings/sqlite_zlib.py
@@ -1,4 +1,5 @@
 SECRET_KEY = "django_tests_secret_key"
+USE_TZ = False
 
 CACHES = {
     "default": {


### PR DESCRIPTION
The failure was caused by:
django.utils.deprecation.RemovedInDjango50Warning:
The default value of USE_TZ will change from False to True in Django 5.0.
Set USE_TZ to False in your project settings if you want to keep
the current default behavior.