### PR TITLE
fix README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -389,6 +389,7 @@ specify a new expiration timeout using the ``persist`` and ``expire`` methods:
     5
 
 The ``pexpire`` method can be used to provide millisecond precision:
+
 .. code-block:: pycon
 
     >>> cache.set("foo", "bar", timeout=22)


### PR DESCRIPTION
Just a quick fix of the README.md file, this used to show `.. code-block:: pycon` has a string instead of using it for the codeblock.