### PR TITLE
Change pickle default version to Python default instead of highest version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,8 +193,8 @@ Pickle version
 
 For almost all values, django-redis uses pickle to serialize objects.
 
-The latest available version of pickle is used by default. If you want set a
-concrete version, you can do it, using ``PICKLE_VERSION`` option:
+The ``pickle.DEFAULT_PROTOCOL`` version of pickle is used by default to ensure safe upgrades and compatibility across Python versions.
+If you want set a concrete version, you can do it, using ``PICKLE_VERSION`` option:
 
 .. code-block:: python
 
@@ -202,7 +202,7 @@ concrete version, you can do it, using ``PICKLE_VERSION`` option:
         "default": {
             # ...
             "OPTIONS": {
-                "PICKLE_VERSION": -1  # Use the latest protocol version
+                "PICKLE_VERSION": -1  # Will use highest protocol version available
             }
         }
     }

--- a/django_redis/serializers/pickle.py
+++ b/django_redis/serializers/pickle.py
@@ -8,7 +8,7 @@ from .base import BaseSerializer
 
 class PickleSerializer(BaseSerializer):
     def __init__(self, options) -> None:
-        self._pickle_version = -1
+        self._pickle_version = pickle.DEFAULT_PROTOCOL
         self.setup_pickle_version(options)
 
         super().__init__(options=options)
@@ -17,6 +17,11 @@ class PickleSerializer(BaseSerializer):
         if "PICKLE_VERSION" in options:
             try:
                 self._pickle_version = int(options["PICKLE_VERSION"])
+                if self._pickle_version > pickle.HIGHEST_PROTOCOL:
+                    raise ImproperlyConfigured(
+                        f"PICKLE_VERSION can't be higher than pickle.HIGHEST_PROTOCOL:"
+                        f" {pickle.HIGHEST_PROTOCOL}"
+                    )
             except (ValueError, TypeError):
                 raise ImproperlyConfigured("PICKLE_VERSION value must be an integer")
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,26 @@
+import pickle
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from django_redis.serializers.pickle import PickleSerializer
+
+
+class TestPickleSerializer:
+    def test_invalid_pickle_version_provided(self):
+        with pytest.raises(
+            ImproperlyConfigured, match="PICKLE_VERSION value must be an integer"
+        ):
+            PickleSerializer({"PICKLE_VERSION": "not-an-integer"})
+
+    def test_setup_pickle_version_not_explicitly_specified(self):
+        serializer = PickleSerializer({})
+        assert serializer._pickle_version == pickle.DEFAULT_PROTOCOL
+
+    def test_setup_pickle_version_too_high(self):
+        with pytest.raises(
+            ImproperlyConfigured,
+            match=f"PICKLE_VERSION can't be higher than pickle.HIGHEST_PROTOCOL:"
+            f" {pickle.HIGHEST_PROTOCOL}",
+        ):
+            PickleSerializer({"PICKLE_VERSION": pickle.HIGHEST_PROTOCOL + 1})


### PR DESCRIPTION
Fixes: #547 regarding using `pickle.DEFAULT_PROTOCOL` as the default pickle version. 