### PR TITLE
Add a "hiredis" extra matching the underlying redis-py extra.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ install_requires =
     Django>=2.2
     redis>=3.0.0
 
+[options.extras_require]
+hiredis = redis[hiredis]>=3.0.0
+
 [coverage:run]
 omit =
     # tests


### PR DESCRIPTION
I noticed that the underlying `redis` library offers the `hiredis` parser as a package extra, but does not install it by default.

Prior to this PR, `django-redis` only set a dependency on `redis` (without the extra), which meant that by default users of `django-redis` were not benefiting from the faster `hiredis` parser. While adding `hiredis` to a project that uses `django-redis` was possible, it was kind of clunky: one could add a direct dependency in the project on either `redis[hiredis]` or on `hiredis` itself. Both of these options would have involved manually making sure that the `django-redis, redis, hiredis` libraries all end up with matching requirements ranges so the project doesn't end up with an unsupported combination of versions.

The alternative I'm proposing in this PR is to expose a `django-redis[hiredis]` extra with a dependency on `redis[hiredis]`. That way, downstream users of `django-redis` can simply install `django-redis[hiredis]` instead of manually managing their own independent dependencies on `redis` and/or `hiredis` for their project.

If the maintainers feel this new extra is worth mentioning in the README, I'd be happy to write up a small new section explaining the feature and its benefits — just let me know.

Thanks for maintaining this awesome library!