### PR TITLE
Follow up on #559 to add news fragment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -886,8 +886,11 @@ Setting True as a value will instruct the django-redis to close all the connecti
     }
 
 SSL/TLS and Self-Signed certificates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In case you encounter a Redis server offering a TLS connection using a self-signed certificate, your settings may look something like:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In case you encounter a Redis server offering a TLS connection using a
+self-signed certificate you may disable certification verification with the
+following:
 
 .. code-block:: python
 

--- a/changelog.d/559.doc
+++ b/changelog.d/559.doc
@@ -1,0 +1,1 @@
+Add documentation on configuring self signed SSL certificates.


### PR DESCRIPTION
From #559 

> A sample setting to connect to a Redis server that's offering a TLS connection using a self-signed certificate.