### PR TITLE
Unblock redis>=4.0.2 (#542, #570)

### DIFF
--- a/changelog.d/542.bugfix
+++ b/changelog.d/542.bugfix
@@ -1,0 +1,1 @@
+Block use with broken redis-py 4.0.0 and 4.0.1

--- a/changelog.d/576.misc
+++ b/changelog.d/576.misc
@@ -1,0 +1,1 @@
+Unblock redis-py >=4.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,10 +38,10 @@ packages =
     django_redis.compressors
 install_requires =
     Django>=2.2
-    redis>=3,<4
+    redis>=3,!=4.0.0,!=4.0.1
 
 [options.extras_require]
-hiredis = redis[hiredis]>=3,<4
+hiredis = redis[hiredis]>=3,!=4.0.0,!=4.0.1
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Fixes #542

Upstream commit https://github.com/redis/redis-py/commit/d2b233384458869270352b8c99ca682ae480da5f that is included with redis-py >=4.0.2 adds method `Redis.sentinel_masters` by making class `Redis` inherit from `SentinelCommands`, where the related code resides.

Related to issue #542, follow-up to pull request #570