### PR TITLE
Upgrading to the latest redis-py release

### DIFF
--- a/changelog.d/607.misc
+++ b/changelog.d/607.misc
@@ -1,0 +1,1 @@
+Added support for the latest version of redis-py, 4.3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ packages =
     django_redis.compressors
 install_requires =
     Django>=2.2
-    redis>=4.3.1,<=4.9.9
+    redis>=4.3.4,<=4.9.9
 
 [options.extras_require]
 hiredis = redis[hiredis]>=4.3.1,<=4.9.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,10 @@ packages =
     django_redis.compressors
 install_requires =
     Django>=2.2
-    redis>=3,!=4.0.0,!=4.0.1
+    redis>=4.3.1,<=4.9.9
 
 [options.extras_require]
-hiredis = redis[hiredis]>=3,!=4.0.0,!=4.0.1
+hiredis = redis[hiredis]>=4.3.1,<=4.9.9
 
 [coverage:run]
 omit =


### PR DESCRIPTION
django-redis currently relies on not the latest version of redis. This is a small PR to bump the version.