### PR TITLE
#609, use pipeline for delete_pattern

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -483,6 +483,15 @@ pattern syntax as the ``keys`` function and returns the number of deleted keys.
     >>> from django.core.cache import cache
     >>> cache.delete_pattern("foo_*")
 
+To achieve the best performance while deleting many keys, you should set ``DJANGO_REDIS_SCAN_ITERSIZE`` to a relatively
+high number (e.g., 100_000) by default in Django settings or pass it directly to the ``delete_pattern``.
+
+
+.. code-block:: pycon
+
+    >>> from django.core.cache import cache
+    >>> cache.delete_pattern("foo_*", itersize=100_000)
+
 Redis native commands
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/changelog.d/609.misc
+++ b/changelog.d/609.misc
@@ -1,0 +1,1 @@
+Speed up deleting multiple keys by a pattern with pipelines and larger itersize

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -393,9 +393,13 @@ class DefaultClient:
 
         try:
             count = 0
+            pipeline = client.pipeline()
+
             for key in client.scan_iter(match=pattern, count=itersize):
-                client.delete(key)
+                pipeline.delete(key)
                 count += 1
+            pipeline.execute()
+
             return count
         except _main_exceptions as e:
             raise ConnectionInterrupted(connection=client) from e


### PR DESCRIPTION
Speed up deleting multiple keys by a pattern with pipelines and larger `itersize` value  #609 