### PR TITLE
feat: Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11"
         django-version:
           - "2.2"
           - "3.1"
@@ -35,7 +34,7 @@ jobs:
           # latest Django with pre-release redis
           - django-version: "4.0"
             redis-version: "master"
-            python-version: "3.11"
+            python-version: "3.10"
 
           # latest redis with pre-release Django
           - django-version: "main"
@@ -45,6 +44,11 @@ jobs:
           # pre-release Django and redis
           - django-version: "main"
             redis-version: "master"
+            python-version: "3.11"
+
+          # Python 3.11 with stable Django and redis
+          - django-version: "4.1"
+            redis-version: "latest"
             python-version: "3.11"
 
         # exclude python 3.6 and 3.7 for django 4.x as they are not supported see https://docs.djangoproject.com/en/dev/releases/4.0/#python-compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,50 +15,51 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
         django-version:
-          - '2.2'
-          - '3.1'
-          - '3.2'
-          - '4.0'
-          - '4.1'
+          - "2.2"
+          - "3.1"
+          - "3.2"
+          - "4.0"
+          - "4.1"
         redis-version:
-          - 'latest'
+          - "latest"
 
         # only test pre-release dependencies for the latest Python
         include:
           # latest Django with pre-release redis
-          - django-version: '4.0'
-            redis-version: 'master'
-            python-version: '3.10'
+          - django-version: "4.0"
+            redis-version: "master"
+            python-version: "3.11"
 
           # latest redis with pre-release Django
-          - django-version: 'main'
-            redis-version: 'latest'
-            python-version: '3.10'
+          - django-version: "main"
+            redis-version: "latest"
+            python-version: "3.11"
 
           # pre-release Django and redis
-          - django-version: 'main'
-            redis-version: 'master'
-            python-version: '3.10'
+          - django-version: "main"
+            redis-version: "master"
+            python-version: "3.11"
 
         # exclude python 3.6 and 3.7 for django 4.x as they are not supported see https://docs.djangoproject.com/en/dev/releases/4.0/#python-compatibility
         exclude:
-          - django-version: '4.1'
-            python-version: '3.6'
+          - django-version: "4.1"
+            python-version: "3.6"
 
-          - django-version: '4.1'
-            python-version: '3.7'
+          - django-version: "4.1"
+            python-version: "3.7"
 
-          - django-version: '4.0'
-            python-version: '3.6'
+          - django-version: "4.0"
+            python-version: "3.6"
 
-          - django-version: '4.0'
-            python-version: '3.7'
+          - django-version: "4.0"
+            python-version: "3.7"
 
     steps:
       - uses: actions/checkout@v2
@@ -120,10 +121,10 @@ jobs:
       fail-fast: false
       matrix:
         tool:
-          - 'black'
-          - 'flake8'
-          - 'isort'
-          - 'mypy'
+          - "black"
+          - "flake8"
+          - "isort"
+          - "mypy"
 
     steps:
       - uses: actions/checkout@v2
@@ -131,7 +132,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Get pip cache dir
         id: pip-cache
@@ -172,7 +173,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Get pip cache dir
         id: pip-cache

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,8 @@ envlist =
     isort
     mypy
     # tests against released versions
-    py{36,37,38,39,310,311}-dj{22,31,32,40,41}-redislatest
+    py{36,37,38,39,310}-dj{22,31,32,40,41}-redislatest
+    py{311}-dj{41}-redislatest
     # tests against unreleased versions
     py311-dj40-redismaster
     py311-djmain-redis{latest,master}

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,10 +73,10 @@ envlist =
     isort
     mypy
     # tests against released versions
-    py{36,37,38,39,310}-dj{22,31,32,40,41}-redislatest
+    py{36,37,38,39,310,311}-dj{22,31,32,40,41}-redislatest
     # tests against unreleased versions
-    py310-dj40-redismaster
-    py310-djmain-redis{latest,master}
+    py311-dj40-redismaster
+    py311-djmain-redis{latest,master}
 
 [gh-actions]
 python =
@@ -85,6 +85,7 @@ python =
     3.8: py38, black, flake8, isort, mypy
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
Currently only Django 4.1 supports Python 3.11. I've added this case to the CI and it works.

I don't know it there's more to this PR