### PR TITLE
add compressed serializers

### DIFF
--- a/django_redis/serializers/compressed.py
+++ b/django_redis/serializers/compressed.py
@@ -1,0 +1,11 @@
+from django.utils.encoding import force_bytes
+
+import lzma
+
+
+class CompressedMixin:
+    def serialize(self, value):
+        return lzma.compress(force_bytes(super(CompressedMixin, self).serialize(value)))
+
+    def deserialize(self, value):
+        return super(CompressedMixin, self).deserialize(lzma.decompress(value))

--- a/django_redis/serializers/compressed_json.py
+++ b/django_redis/serializers/compressed_json.py
@@ -1,0 +1,6 @@
+from .compressed import CompressedMixin
+from .json import JSONSerializer
+
+
+class CompressedJSONSerializer(CompressedMixin, JSONSerializer):
+    pass

--- a/django_redis/serializers/compressed_msgpack.py
+++ b/django_redis/serializers/compressed_msgpack.py
@@ -1,0 +1,6 @@
+from .compressed import CompressedMixin
+from .msgpack import MSGPackSerializer
+
+
+class CompressedMSGPackSerializer(CompressedMixin, MSGPackSerializer):
+    pass

--- a/django_redis/serializers/compressed_pickle.py
+++ b/django_redis/serializers/compressed_pickle.py
@@ -1,0 +1,6 @@
+from .compressed import CompressedMixin
+from .pickle import PickleSerializer
+
+
+class CompressedPickleSerializer(CompressedMixin, PickleSerializer):
+    pass


### PR DESCRIPTION
Often JSON/msgpack/pickle can produce large blobs with a lot of duplicated data.

By using a fast compressor, this can result in both faster writing and reading because the "bandwidth" between the Django layer and the database is smaller, and therefore more efficient. Yes, compressing takes some time as well, but for certain types of data (like pickled dataframes for example), this might pay off, and overall speed up processing.