### PR TITLE
Add Django 4.2 to test matrix and classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - '3.2'
           - '4.0'
           - '4.1'
+          - '4.2'
         redis-version:
           - 'latest'
 
@@ -43,8 +44,13 @@ jobs:
             redis-version: 'latest'
             python-version: '3.11'
 
+          # Django 4.2 and python 3.11 with latest redis
+          - django-version: '4.2'
+            redis-version: 'latest'
+            python-version: '3.11'
+
           # latest Django with pre-release redis
-          - django-version: '4.1'
+          - django-version: '4.2'
             redis-version: 'master'
             python-version: '3.11'
 

--- a/changelog.d/668.misc
+++ b/changelog.d/668.misc
@@ -1,0 +1,1 @@
+Run actions & tox against Django 4..2

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
@@ -72,9 +73,9 @@ envlist =
     isort
     mypy
     # tests against released versions
-    py{36,37,38,39,310,311}-dj{22,31,32,40,41}-redislatest
+    py{36,37,38,39,310,311}-dj{22,31,32,40,41,42}-redislatest
     # tests against unreleased versions
-    py311-dj41-redismaster
+    py311-dj42-redismaster
     py311-djmain-redis{latest,master}
 
 [gh-actions]
@@ -91,6 +92,7 @@ DJANGO =
     3.2: dj32
     4.0: dj40
     4.1: dj41
+    4.2: dj42
     main: djmain
 REDIS =
     latest: redislatest
@@ -116,6 +118,7 @@ deps =
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     msgpack>=0.6.0
     pytest


### PR DESCRIPTION
Currently, testing takes place against 4.1 and main. This PR fills the hole of the test matrix by adding 4.2. 