### PR TITLE
Add Python 3.12 to test matrix and add classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         python-version:
           - '3.10'
           - '3.11'
+          - '3.12'
         django-version:
           - '4.2'
           - '5.0'
@@ -35,6 +36,7 @@ jobs:
           - django-version: '4.2'
             redis-version: 'latest'
             python-version: '3.9'
+
 
           # latest Django with pre-release redis
           - django-version: '5.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,21 +37,20 @@ jobs:
             redis-version: 'latest'
             python-version: '3.9'
 
-
           # latest Django with pre-release redis
           - django-version: '5.1'
             redis-version: 'master'
-            python-version: '3.11'
+            python-version: '3.12'
 
           # latest redis with pre-release Django
           - django-version: 'main'
             redis-version: 'latest'
-            python-version: '3.11'
+            python-version: '3.12'
 
           # pre-release Django and redis
           - django-version: 'main'
             redis-version: 'master'
-            python-version: '3.11'
+            python-version: '3.12'
 
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/689.misc
+++ b/changelog.d/689.misc
@@ -1,0 +1,1 @@
+Added support for Python 3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries
     Topic :: Utilities
 
@@ -57,7 +58,8 @@ envlist =
     ruff
     mypy
     # tests against released versions
-    py{38,39,310,311}-dj{42,50,51}-redislatest
+    py{38,39}-dj{42}-redislatest
+    py{310,311,312}-dj{42,50,51}-redislatest
     # tests against unreleased versions
     py311-dj51-redismaster
     py311-djmain-redis{latest,master}
@@ -68,6 +70,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
Everything seems fine for Python 3.12 and no change are required. 