### PR TITLE
Pin pytest to <7

### DIFF
--- a/changelog.d/690.misc
+++ b/changelog.d/690.misc
@@ -1,0 +1,1 @@
+Pin pytest to <7.0 until compatibility issues are resolved

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,7 @@ deps =
     dj42: Django>=4.2,<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     msgpack>=0.6.0
-    pytest
+    pytest<7.0.0
     pytest-cov
     pytest-django
     pytest-pythonpath


### PR DESCRIPTION
This PR pins pytest to < 7.0 to mitigate #690 