### PR TITLE
Use ubuntu latest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       Django ${{ matrix.django-version }},
       Redis.py ${{ matrix.redis-version }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/changelog.d/703.misc
+++ b/changelog.d/703.misc
@@ -1,0 +1,1 @@
+Use ubuntu-latest for CI


### PR DESCRIPTION
Since we dropped python3.6 we can use the latest version of ubuntu available in GitHub