### PR TITLE
Draft: Add support for NX, XX, GT and LT to expire and pexpire

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -317,6 +317,10 @@ class DefaultClient:
         timeout: ExpiryT,
         version: Optional[int] = None,
         client: Optional[Redis] = None,
+        nx: bool = False,
+        xx: bool = False,
+        gt: bool = False,
+        lt: bool = False,
     ) -> bool:
         if timeout is DEFAULT_TIMEOUT:
             timeout = self._backend.default_timeout  # type: ignore
@@ -326,7 +330,7 @@ class DefaultClient:
 
         key = self.make_key(key, version=version)
 
-        return client.expire(key, timeout)
+        return client.expire(key, timeout, nx, xx, gt, lt)
 
     def pexpire(
         self,
@@ -334,6 +338,10 @@ class DefaultClient:
         timeout: ExpiryT,
         version: Optional[int] = None,
         client: Optional[Redis] = None,
+        nx: bool = False,
+        xx: bool = False,
+        gt: bool = False,
+        lt: bool = False,
     ) -> bool:
         if timeout is DEFAULT_TIMEOUT:
             timeout = self._backend.default_timeout  # type: ignore
@@ -343,7 +351,7 @@ class DefaultClient:
 
         key = self.make_key(key, version=version)
 
-        return bool(client.pexpire(key, timeout))
+        return bool(client.pexpire(key, timeout, nx, xx, gt, lt))
 
     def pexpire_at(
         self,

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -171,19 +171,57 @@ class ShardClient(DefaultClient):
 
         return super().persist(key=key, version=version, client=client)
 
-    def expire(self, key, timeout, version=None, client=None):
+    def expire(
+        self,
+        key,
+        timeout,
+        version=None,
+        client=None,
+        nx=False,
+        xx=False,
+        gt=False,
+        lt=False,
+    ):
         if client is None:
             key = self.make_key(key, version=version)
             client = self.get_server(key)
 
-        return super().expire(key=key, timeout=timeout, version=version, client=client)
+        return super().expire(
+            key=key,
+            timeout=timeout,
+            version=version,
+            client=client,
+            nx=nx,
+            xx=xx,
+            gt=gt,
+            lt=lt,
+        )
 
-    def pexpire(self, key, timeout, version=None, client=None):
+    def pexpire(
+        self,
+        key,
+        timeout,
+        version=None,
+        client=None,
+        nx=False,
+        xx=False,
+        gt=False,
+        lt=False,
+    ):
         if client is None:
             key = self.make_key(key, version=version)
             client = self.get_server(key)
 
-        return super().pexpire(key=key, timeout=timeout, version=version, client=client)
+        return super().pexpire(
+            key=key,
+            timeout=timeout,
+            version=version,
+            client=client,
+            nx=nx,
+            xx=xx,
+            gt=gt,
+            lt=lt,
+        )
 
     def pexpire_at(self, key, when: Union[datetime, int], version=None, client=None):
         """


### PR DESCRIPTION
Fixes #730 

@WisdomPill 

- Added support for nx, xx, gt and lt to `django_redis/client/default.py` and `django_redis/client/sharded.py`
- Add tests to `tests/test_backend.py`

Questions/TODOs [PR marked as draft]:
- Update changelog
- Should these flags be supported for `expire_at` and `pexpire_at`?
- A comment on #733 asks to add typing to `expire` and `pexpire` functions in `django_redis/client/sharded.py`. While I can go ahead and add it, the current implementation does not have typing in the function already, is this deliberate?