### PR TITLE
fix incorrect namespacing applied to Redis hash field keys

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -113,9 +113,21 @@ lint.select = [
 ]
 
 lint.ignore = [
-  "COM812", # missing trailing comma, covered by black
-  "ANN101", # ignore missing type annotation in self parameter
-  "S311", # ignore Standard pseudo-random generators because they are not used for cryptographic purposes
+  # missing trailing comma, covered by black
+  # docs: https://docs.astral.sh/ruff/rules/missing-trailing-comma/
+  "COM812",
+  # ignore missing type annotation in self parameter
+  # docs: https://docs.astral.sh/ruff/rules/missing-type-self/#missing-type-self-ann101
+  "ANN101",  
+  # ignore builtin import shadowing
+  # docs: https://docs.astral.sh/ruff/rules/builtin-import-shadowing/#builtin-import-shadowing-a004
+  "A004",
+  # ignore Standard pseudo-random generators because they are not used for cryptographic purposes
+  # docs: https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/#suspicious-non-cryptographic-random-usage-s311
+  "S311",
+  # ignore stdlib module shadowing
+  # docs: https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/
+  "A005",
 ]
 
 fix = true

--- a/changelog.d/765.bugfix
+++ b/changelog.d/765.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect namespacing applied to Redis hash field keys

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -1099,8 +1099,8 @@ class DefaultClient:
 
     def hset(
         self,
-        name: str,
-        key: KeyT,
+        name: KeyT,
+        key: str,
         value: EncodableT,
         version: Optional[int] = None,
         client: Optional[Redis] = None,
@@ -1111,14 +1111,15 @@ class DefaultClient:
         """
         if client is None:
             client = self.get_client(write=True)
-        nkey = self.make_key(key, version=version)
+
+        name = self.make_key(name, version=version)
         nvalue = self.encode(value)
-        return int(client.hset(name, nkey, nvalue))
+        return int(client.hset(name, key, nvalue))
 
     def hdel(
         self,
-        name: str,
-        key: KeyT,
+        name: KeyT,
+        key: str,
         version: Optional[int] = None,
         client: Optional[Redis] = None,
     ) -> int:
@@ -1128,12 +1129,14 @@ class DefaultClient:
         """
         if client is None:
             client = self.get_client(write=True)
-        nkey = self.make_key(key, version=version)
-        return int(client.hdel(name, nkey))
+
+        name = self.make_key(name, version=version)
+        return int(client.hdel(name, key))
 
     def hlen(
         self,
-        name: str,
+        name: KeyT,
+        version: Optional[int] = None,
         client: Optional[Redis] = None,
     ) -> int:
         """
@@ -1141,11 +1144,14 @@ class DefaultClient:
         """
         if client is None:
             client = self.get_client(write=False)
+
+        name = self.make_key(name, version=version)
         return int(client.hlen(name))
 
     def hkeys(
         self,
-        name: str,
+        name: KeyT,
+        version: Optional[int] = None,
         client: Optional[Redis] = None,
     ) -> List[Any]:
         """
@@ -1153,15 +1159,17 @@ class DefaultClient:
         """
         if client is None:
             client = self.get_client(write=False)
+
+        name = self.make_key(name, version=version)
         try:
-            return [self.reverse_key(k.decode()) for k in client.hkeys(name)]
+            return [k.decode() for k in client.hkeys(name)]
         except _main_exceptions as e:
             raise ConnectionInterrupted(connection=client) from e
 
     def hexists(
         self,
-        name: str,
-        key: KeyT,
+        name: KeyT,
+        key: str,
         version: Optional[int] = None,
         client: Optional[Redis] = None,
     ) -> bool:
@@ -1170,5 +1178,6 @@ class DefaultClient:
         """
         if client is None:
             client = self.get_client(write=False)
-        nkey = self.make_key(key, version=version)
-        return bool(client.hexists(name, nkey))
+
+        name = self.make_key(name, version=version)
+        return bool(client.hexists(name, key))


### PR DESCRIPTION
This changes addresses an issue where namespacing was applied to the field instead of the key.


**behavior:**
- before: Namespacing was applied to the field parameter (e.g, hash key) when it should have been applied to the key parameter.
- after: Namespacing is correctly applied to the key parameter, leaving the field name unaltered.

