### PR TITLE
Drop support for Django 5.0 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           - '3.12'
         django-version:
           - '4.2'
-          - '5.0'
           - '5.1'
           - '5.2'
         redis-version:

--- a/changelog.d/779.misc
+++ b/changelog.d/779.misc
@@ -1,0 +1,1 @@
+Drop support for Django 5.0 (EOL)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Environment :: Web Environment
     Framework :: Django
     Framework :: Django :: 4.2
-    Framework :: Django :: 5.0
     Framework :: Django :: 5.1
     Framework :: Django :: 5.2
     Intended Audience :: Developers
@@ -38,7 +37,7 @@ packages =
     django_redis.serializers
     django_redis.compressors
 install_requires =
-    Django>=4.2
+    Django>=4.2,<5.3,!=5.0.*
     redis>=4.0.2
 
 [options.extras_require]
@@ -77,7 +76,6 @@ python =
 [gh-actions:env]
 DJANGO =
     4.2: dj42
-    5.0: dj50
     5.1: dj51
     5.2: dj52
     main: djmain
@@ -92,7 +90,6 @@ commands =
 
 deps =
     dj42: Django>=4.2,<5.0
-    dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<6.0
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Support for Django 5.0 ended by April 2025

https://upgradedjango.com/5.0/