### PR TITLE
Update hiredis usage instructions in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -785,20 +785,20 @@ It is also possible to set some caches as sentinels and some as not:
 Pluggable parsers
 ~~~~~~~~~~~~~~~~~
 
-redis-py (the Python Redis client used by django-redis) comes with a pure
-Python Redis parser that works very well for most common task, but if you want
-some performance boost, you can use hiredis.
+`redis-py`_, the Python Redis client used by django-redis, will automatically
+use a C-based parser if the `hiredis`_ package is installed in your environment.
+This can provide a significant performance boost for parsing Redis replies.
 
-hiredis is a Redis client written in C and it has its own parser that can be
-used with django-redis.
+To take advantage of this, simply install the `hiredis` package with pip:
 
-.. code-block:: python
+.. code-block:: console
 
-    "OPTIONS": {
-        "PARSER_CLASS": "redis.connection.HiredisParser",
-    }
+    $ python -m pip install hiredis
 
-Note: if using version 5 of redis-py, use ``"redis.connection._HiredisParser"`` for the ``PARSER_CLASS`` due to an internal rename of classes within that package.
+No additional configuration in your Django settings is required. django-redis
+will use the faster parser automatically.
+
+.. _hiredis: https://pypi.org/project/hiredis/
 
 Pluggable clients
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The documentation for enabling the `hiredis` parser is outdated. It currently instructs users to set the `PARSER_CLASS` option, which is no longer the recommended or necessary approach.

`redis-py` automatically detects and uses the high-performance `hiredis` parser if the package is installed in the environment. No additional configuration is required from the user.

This PR updates the "Pluggable parsers" section in `README.rst` to align with the current behavior by:

-  Removing the obsolete `PARSER_CLASS` configuration example.
-  Clarifying that `hiredis` is used automatically by default when installed.
-  Providing the simple `pip install hiredis` command as the only required step.

This change makes the documentation more accurate and user-friendly, ensuring that users can easily leverage the performance benefits of hiredis without confusion.

Depends on : 
- https://github.com/jazzband/django-redis/issues/750#event-19307854748