### PR TITLE
Fix RedisCache.close() method to check for client existence before closing.

### DIFF
--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -185,7 +185,8 @@ class RedisCache(BaseCache):
 
     @omit_exception
     def close(self, **kwargs):
-        self.client.close(**kwargs)
+        if self._client is not None:
+            self.client.close()
 
     @omit_exception
     def touch(self, *args, **kwargs):


### PR DESCRIPTION
This pull request makes a small update to the `close` method in the `django_redis/cache.py` file to prevent errors when the cache client is not initialized.

* The `close` method now checks if `_client` is not `None` before attempting to close the client.

A recent bug with a patch showed us that there can be many instances where the `_client` in `RedisCache` is closed before it gets an opportunity to instantiate.  This means that django-redis will create the connection just to immediately close it.

This simple update protects against that inefficiency.