### PR TITLE
fix: accept and ignore close() kwargs from request_finished signal (#…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,42 +15,37 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
+          - '3.14'
         django-version:
-          - '4.2'
-          - '5.1'
           - '5.2'
+          - '6.0'
         redis-version:
           - 'latest'
 
+        # Django 6.0 requires Python 3.12+
+        exclude:
+          - python-version: '3.11'
+            django-version: '6.0'
+
         # Only test pre-release dependencies for the latest Python.
         include:
-          # Django 4.2 and python 3.9 with latest redis
-          - django-version: '4.2'
-            redis-version: 'latest'
-            python-version: '3.9'
-          
-          # latest Django with latest redis
-          - django-version: '5.2'
-            redis-version: 'latest'
-            python-version: '3.13'
-
           # latest Django with pre-release redis
-          - django-version: '5.2'
+          - django-version: '6.0'
             redis-version: 'master'
-            python-version: '3.13'
+            python-version: '3.14'
 
           # pre-release Django with latest redis
           - django-version: 'main'
             redis-version: 'latest'
-            python-version: '3.13'
+            python-version: '3.14'
 
           # pre-release Django and pre-release redis
           - django-version: 'main'
             redis-version: 'master'
-            python-version: '3.13'
+            python-version: '3.14'
 
     steps:
       - uses: actions/checkout@v6

--- a/changelog.d/787.bugfix
+++ b/changelog.d/787.bugfix
@@ -1,0 +1,4 @@
+Fix ``TypeError: close() got an unexpected keyword argument 'signal'``
+raised on every request when Django's ``request_finished`` signal calls
+``RedisCache.close()``. The cache backend no longer forwards keyword
+arguments to the underlying client's ``close()``.

--- a/django_redis/__init__.py
+++ b/django_redis/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (6, 0, 0)
+VERSION = (6, 0, 1)
 __version__ = ".".join(map(str, VERSION))
 
 

--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -185,7 +185,11 @@ class RedisCache(BaseCache):
 
     @omit_exception
     def close(self, **kwargs):
-        self.client.close(**kwargs)
+        # Accept and ignore arbitrary kwargs (e.g. signal=, sender=) that
+        # Django's request_finished signal dispatcher passes in. The
+        # underlying client's close() takes no arguments — see
+        # jazzband/django-redis#787.
+        self.client.close()
 
     @omit_exception
     def touch(self, *args, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,25 +12,23 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 4.2
-    Framework :: Django :: 5.1
     Framework :: Django :: 5.2
+    Framework :: Django :: 6.0
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Software Development :: Libraries
     Topic :: Utilities
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.11
 packages =
     django_redis
     django_redis.client
@@ -38,7 +36,7 @@ packages =
     django_redis.serializers
     django_redis.compressors
 install_requires =
-    Django>=4.2,<5.3,!=5.0.*
+    Django>=5.2,<6.1
     redis>=4.0.2
 
 [options.extras_require]
@@ -58,26 +56,23 @@ envlist =
     ruff
     mypy
     # tests against released versions
-    py39-dj{42}-redislatest
-    py{310,311,312}-dj{42,50,51,52}-redislatest
-    py313-dj{51,52}-redislatest
+    py{311,312,313,314}-dj52-redislatest
+    py{312,313,314}-dj60-redislatest
     # tests against unreleased versions
-    py313-dj52-redismaster
-    py313-djmain-redis{latest,master}
+    py314-dj60-redismaster
+    py314-djmain-redis{latest,master}
 
 [gh-actions]
 python =
-    3.9: py39, ruff, mypy
-    3.10: py310
-    3.11: py311
+    3.11: py311, ruff, mypy
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 DJANGO =
-    4.2: dj42
-    5.1: dj51
     5.2: dj52
+    6.0: dj60
     main: djmain
 REDIS =
     latest: redislatest
@@ -89,9 +84,8 @@ commands =
   {envpython} -m pytest -n 4 {posargs}
 
 deps =
-    dj42: Django>=4.2,<5.0
-    dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<6.0
+    dj60: Django>=6.0,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     msgpack>=0.6.0
     pytest

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -537,6 +537,18 @@ class TestDjangoRedisCache:
         cache.close()
         assert mock.called
 
+    def test_close_accepts_signal_kwargs(
+        self, cache: RedisCache, mocker: MockerFixture,
+    ):
+        # Regression test for jazzband/django-redis#787:
+        # Django's request_finished signal calls cache.close() with
+        # signal= and sender= kwargs. RedisCache.close() must accept
+        # them but must NOT forward them to the underlying client,
+        # because DefaultClient.close() takes no keyword arguments.
+        mock = mocker.patch.object(cache.client, "close")
+        cache.close(signal=mocker.Mock(), sender=mocker.Mock())
+        mock.assert_called_once_with()
+
     def test_ttl(self, cache: RedisCache):
         cache.set("foo", "bar", 10)
         ttl = cache.ttl("foo")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -538,7 +538,9 @@ class TestDjangoRedisCache:
         assert mock.called
 
     def test_close_accepts_signal_kwargs(
-        self, cache: RedisCache, mocker: MockerFixture,
+        self,
+        cache: RedisCache,
+        mocker: MockerFixture,
     ):
         # Regression test for jazzband/django-redis#787:
         # Django's request_finished signal calls cache.close() with


### PR DESCRIPTION
…787)

`RedisCache.close()` was forwarding `**kwargs` to `self.client.close()`, which since django-redis 6.0.0 (DefaultClient signature change in c7be6cc) takes no arguments. Django's `request_finished` signal passes `signal=` and `sender=`, so every request raised
`TypeError: close() got an unexpected keyword argument 'signal'`.

Also bumps the package to 6.0.1 and refreshes the CI/setup matrix: drop EOL Python 3.9/3.10 and Django 4.2/5.1; add Python 3.14 and Django 6.0 (Django 6.0 excluded on Python 3.11).

Fix #787 