### PR TITLE
Fix typos in source files

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -747,7 +747,7 @@ class DefaultClient(
         client: Redis | None = None,
     ) -> int:
         """
-        Decreace delta to value in the cache. If the key does not exist, raise a
+        Decrease delta to value in the cache. If the key does not exist, raise a
         ValueError exception.
         """
         return self._incr(key=key, delta=-delta, version=version, client=client)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def patch_itersize_setting() -> Iterable[None]:
-    # destroy cache to force recreation with overriden settings
+    # destroy cache to force recreation with overridden settings
     del caches["default"]
     with override_settings(DJANGO_REDIS_SCAN_ITERSIZE=30):
         yield
@@ -387,7 +387,7 @@ class TestDjangoRedisCache:
         assert res == 1
         cache.delete("num")
 
-        # since key doesnt exist it is set to the delta value, 10 in this case
+        # since key doesn't exist it is set to the delta value, 10 in this case
         cache.incr("num", 10, ignore_key_check=True)
         res = cache.get("num")
         assert res == 10


### PR DESCRIPTION
Fix minor typos found by codespell in .py files:

- `Decreace` → `Decrease` in `django_redis/client/default.py` (docstring for `decr` method)
- `overriden` → `overridden` in `tests/test_backend.py` (comment)
- `doesnt` → `doesn't` in `tests/test_backend.py` (comment)